### PR TITLE
Implement Visual Edit typing loop: auto-pair, checkboxes, emoji

### DIFF
--- a/docs/visual-editing-quality.md
+++ b/docs/visual-editing-quality.md
@@ -31,7 +31,7 @@ Markion's Visual Edit mode is WYSIWYG-first: rendering is the default presentati
 Every user-visible construct belongs to exactly one of three classes:
 
 1. **Rendered WYSIWYG** — shown in its rendered form. Dedicated field/payload editors (fenced code payload plus the hover/caret-revealed info-token chip, block math, diagrams, Markdown and inline-HTML images with the collapsible whole-span source toggle above the image, GFM tables with cell editors, HTML blocks via `VisualBlockEditor::Html`) are the rendered form of their constructs. Covers prose rows, headings (including empty ATX headings), lists/task items (including empty items), blockquote flows, GFM alerts, horizontal rules, whitespace rows, footnote definitions/references, link reference definitions, and HTML blocks (shared pipeline plus collapsible source payload).
-2. **Progressive-reveal WYSIWYG** — rendered by default; reveals its smallest complete source syntax group when the caret enters it. Covers emphasis, strong, strikethrough, inline code, highlight, super/subscript, links (including reference-style and angle-bracket autolinks), inline math, backslash escapes, decoded HTML entity references (proven named table, including multi-codepoint names), the supported inline-HTML subset (style pairs with ignorable `class`/`id`/`clear`, `<br>`, inline `<img>`), inert unknown inline-HTML atoms, structural prefixes, and heading attributes.
+2. **Progressive-reveal WYSIWYG** — rendered by default; reveals its smallest complete source syntax group when the caret enters it. Covers emphasis, strong, strikethrough, inline code, highlight, super/subscript, links (including reference-style and angle-bracket autolinks), inline math, backslash escapes, decoded HTML entity references (proven named table, including multi-codepoint names), `:shortcode:` emoji tokens, the supported inline-HTML subset (style pairs with ignorable `class`/`id`/`clear`, `<br>`, inline `<img>`), inert unknown inline-HTML atoms, structural prefixes, and heading attributes.
 3. **WYSIWYG coverage gap** — currently shows authored source as a transitional affordance; tracked on the roadmap below until a change closes it.
 
 The old five-class taxonomy folded its "dedicated editor" class into rendered WYSIWYG and reclassified "source island" as roadmap gaps.
@@ -47,16 +47,17 @@ Prioritized open gaps (refreshed 2026-08-29; each closes via a future change cit
 | 3 | Unclosed/malformed fenced code | Code island | Rendered (highlighted code, fences visible) | Small | `src/visual.rs:1164-1268` |
 | 4 | Reference-style/malformed inline images | Renders unfocused; focused → island; no field controls | Rendered | Medium | `src/inline_edit.rs:66-82` (`LinkType::Inline` only) |
 | 5 | Malformed tables (ragged rows) | Best-effort grid unfocused; island focused | Rendered | Small | `src/table.rs:182-221` |
-| 7 | Task-list checkbox click | Glyph not interactive | Rendered (click toggles `[ ]`/`[x]`) | Small | `src/app/preview.rs:2919-2944` |
 | 9 | GFM definition lists | Not enabled; `: Def` renders as literal prose | Rendered | Small–Medium | `src/parse.rs:1738-1747` (`ENABLE_DEFINITION_LIST` absent) |
 | 11 | Math render-failure states | Island on focus while KaTeX is Pending/Error | Rendered (payload editor until Ready) | Small | `src/app/preview.rs:3149-3151` |
 | 12 | Residual gap bytes between known blocks | Lightweight Unsupported island (catch-all) | Closed construct-by-construct | — | `src/visual.rs:857-892` |
+
+Closed in `add-visual-edit-typing-loop`: task-list checkbox click (former gap 7) toggles `[ ]`/`[x]` on the Visual Edit glyph; unfocused `:shortcode:` tokens render as emoji glyphs with progressive source reveal.
 
 Closed in `keep-empty-structure-visual-and-soften-islands`: empty ATX headings and empty list items (former gap 10) stay rendered with prefix reveal; remaining source islands use lightweight chrome instead of a padded bordered card.
 
 Closed in `improve-visual-edit-html-rendering`: unsupported inline HTML (former gap 6) is mixed inert atoms; angle-bracket autolinks (former gap 8) share link reveal; residual named/multi-codepoint entities (former gap 13) decode through the proven tables.
 
-Reviewed divergences (deliberate, not gaps): bare-URL autolinking and `:emoji:` conversion are Preview-only (`src/parse.rs` extended-inline vs Visual Edit `visual_markdown_options`); GFM *pipe*-table cells that contain HTML `<img>` stay flattened to alt/URL text (Read-mode parity). HTML `<td>`/`<th>` images and links render through the HTML-parts table grid.
+Reviewed divergences (deliberate, not gaps): bare-URL autolinking remains Preview-only (`src/parse.rs` extended-inline vs Visual Edit `visual_markdown_options`); GFM *pipe*-table cells that contain HTML `<img>` stay flattened to alt/URL text (Read-mode parity). HTML `<td>`/`<th>` images and links render through the HTML-parts table grid. `:emoji:` shortcodes now render on both Preview and unfocused Visual Edit.
 
 ## Source-Range Invariants
 

--- a/openspec/changes/add-visual-edit-typing-loop/.openspec.yaml
+++ b/openspec/changes/add-visual-edit-typing-loop/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-12

--- a/openspec/changes/add-visual-edit-typing-loop/design.md
+++ b/openspec/changes/add-visual-edit-typing-loop/design.md
@@ -1,0 +1,86 @@
+## Context
+
+See proposal.md for motivation. Visual Edit already projects headings, lists, quotes, emphasis, and `:shortcode:` emoji through a source-backed `VisualBlock` stream. Typing still goes through `replace_text_in_range` (`src/app/editor_element.rs`) with no pairing; task-list rows paint `☐`/`☑` as inert text (`src/app/preview.rs` list-item chrome); emoji lookup is a closed `match` in `src/parse.rs` (`emoji_for_shortcode`) with no completer; structural prefixes reveal when the caret is inside or at the end of `VisualBlockPrefix.source_range`.
+
+Invariants that shape the approach: `MarkdownDocument.text` is the only persisted representation; derived preview/visual/outline/stats stay `Arc` caches keyed by document version; showing UI (slash palette, find overlay) today does not bump that version; `crates/*` stay GPUI-free.
+
+```
+  keystroke / click
+        │
+        ▼
+  interaction-only? (palette filter, hover, prefix hide after caret left)
+        │ yes ──▶ no version bump, no cache rebuild
+        ▼ no
+  one canonical SourceEdit (pair / toggle [ ]↔[x] / insert :name: / Enter)
+        │
+        ▼
+  existing dirty / undo / autosave / recovery
+        │
+        ▼
+  version++ ──▶ incremental Visual Edit derivation (fallback to full parse)
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Pairing, checkbox toggle, and emoji confirm are ordinary source mutations with one-undo semantics.
+- Palette open/filter/dismiss and unfocused prefix hiding are interaction-only.
+- Task-checkbox click leaves the WYSIWYG coverage gap class.
+
+**Non-Goals (design-level):**
+
+- A second rich-text document or inferred checkbox/emoji object store.
+- Pairing logic inside `crates/*` (keep GPUI-free members unaware of keystrokes).
+- Reworking slash-command ownership; emoji reuses its chrome pattern only.
+
+## Decisions
+
+### D1: Auto-pair at the text-input boundary, not in the parser
+
+Intercept collapsed or ranged inserts in the shared source-input path used by the source editor and Visual Edit prose (and Visual Edit table-cell editors), *before* `prepare_range_mutation`. For a single typed opener (`*`, `_`, `` ` ``, `$`, `(`, `[`, `{`, `"`, `'`) with an empty selection, insert opener+closer and place the caret between them. For a non-empty selection, wrap it. If the next source character is already the matching closer, skip over it instead of inserting. Backspace on an empty pair deletes both characters. A preceding `\` suppresses pairing. IME marked ranges skip pairing until commit.
+
+Do **not** pair `=` (assignment/`==` highlight is too ambiguous in prose). Do **not** pair inside fenced-code, block-math, or diagram payload editors.
+
+**Why not a keymap of hidden insert-pair actions?** Platform IME and Visual Edit projection already funnel through one replace helper; a second action table would miss IME commits and cell editors.
+
+**Why not pair in `crates/markdown`?** Pairing is an editor policy over UTF-8 offsets, not a parse concern; putting it in a member crate would either pull GPUI or fork a second mutation API.
+
+### D2: Unfocused structural prefixes hide from caret ownership, not from a second rewrite
+
+Keep the existing prefix-reveal predicate (caret inside prefix, or at prefix end, or empty payload that owns the caret). After Enter (or any caret move) the previous heading/list/quote/task row no longer owns the caret, so its `#` / `-` / `1.` / `>` / `- [ ]` source stays in `MarkdownDocument.text` but is not painted. No extra source edit is required to hide markers.
+
+Additionally, a Visual Edit paragraph whose line is exactly a typed ATX/list/task/quote prefix (with optional title text after ATX) must be reclassified by the *next ordinary derivation* as that block — the existing pulldown-cmark path already does this once the line is a heading/list/quote; tests must lock that the unfocused row then shows the rendered glyph, not the raw marker characters as prose.
+
+### D3: Checkbox click mutates the proven task-marker bytes
+
+The painted `☐`/`☑` column is a hit target only in Visual Edit, and only when the prefix is *not* revealed (while revealed, the user edits `- [ ]` as source). A primary click maps to the owning `VisualBlock`'s task prefix and replaces the checkbox token `[ ]` ↔ `[x]` (`[X]` normalizes to `[x]` on toggle-off) as one checked mutation. The click MUST NOT insert a caret into the item text as a side effect beyond placing the caret in that item so undo selection is defined. Read and Split Preview stay non-editing.
+
+**Why not a hidden Format action only?** The gap is pointer interaction on the glyph; keyboard Format → Task List already exists and must keep wrapping/toggling list type, not this glyph.
+
+### D4: Emoji completer is a sibling of slash state, inserting `:shortcode:`
+
+Track a per-tab `EmojiQuery { start, query, selected }` analogous to `SlashCommandState`. Trigger when the user types `:` at a word boundary (start of line, whitespace, or opening punctuation) outside code/math/diagram payloads and outside an IME composition. Filter the maintained shortcode table by ASCII prefix; render a localized palette (reuse slash-command layout: occluded panel, selected row, click/Enter/Tab confirm, Esc dismiss). Confirm replaces the open `:query` with `:name:` (closing colon included) as one undoable edit. Canonical source stays the shortcode; preview/Visual Edit continue to render the glyph through the existing extended-inline parser.
+
+Expand `emoji_for_shortcode` into a queryable static table (current entries plus a modest common GitHub-name set). No new crate, no network. If slash palette is open (line starts with `/`), slash wins and `:` inside that query does not open emoji.
+
+### D5: Auto-pair preference is a General boolean defaulting on
+
+Persist `markdown_auto_pair` in `config.toml` (bool, default `true`, missing/invalid → true). Preferences → General toggle, included in reset. Pairing checks this flag at insert time; toggling is presentation/policy only (no document version bump).
+
+## Risks / Trade-offs
+
+- [Pairing fights CJK/IME or `$100`] → Skip while a marked range is active; preference off; do not pair `=`.
+- [Checkbox click vs caret placement on the same row] → Hit-test the marker column first; a miss falls through to existing caret placement.
+- [Emoji `:` vs time `12:30` or URLs] → Require a word-boundary `:` and ASCII shortcode charset; ignore `://`.
+- [Prefix hide looks like data loss] → Source still contains markers; focusing the row reveals them (existing progressive-reveal). Tests assert version-stable hide on caret leave.
+- [Larger emoji table on the typing path] → Static `&[(&str, &str)]` prefix filter, bounded visible rows; no per-keystroke parse of the whole document.
+
+## Migration Plan
+
+- Absent `markdown_auto_pair` → on (Typora-like). No document migration.
+- Rollback: revert the change; documents remain valid Markdown (`:name:` and `[x]` unchanged).
+
+## Open Questions
+
+None that affect the spec or task breakdown. Palette row cap (about 8–12) can be tuned in implementation without changing observable confirm/dismiss behavior.

--- a/openspec/changes/add-visual-edit-typing-loop/proposal.md
+++ b/openspec/changes/add-visual-edit-typing-loop/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Visual Edit already renders headings, lists, quotes, emphasis, and emoji shortcodes, but the *typing* loop still feels like a preview you can poke rather than Typora-style live Markdown: delimiters are not auto-paired, leaving a heading or list by pressing Enter does not reliably hide that row's block markers, task-list checkboxes are inert glyphs (roadmap gap 7), and typing `:` never offers shortcode completion. Closing this loop is the highest-leverage way to make Visual Edit feel like writing, not like editing source through a projection.
+
+## What Changes
+
+- Auto-pair Markdown and matching delimiters while typing on an editing surface (`*`, `_`, `` ` ``, `$`, `=`, brackets/quotes): insert the closer after the caret, wrap a non-empty selection, skip the closer when it is already the next character, and delete the empty pair on Backspace. A persisted General preference (`markdown_auto_pair`, default on) can disable it.
+- After Enter (or any caret move that leaves a heading, list, task, or quote row), hide that row's structural prefixes immediately and show the rendered marker; a just-typed ATX / list / task / quote prefix at line start must reclassify as that block so Enter does not leave `#` / `-` as visible prose.
+- Clicking the Visual Edit task-list checkbox glyph toggles `[ ]` / `[x]` as one exact source mutation. Close the WYSIWYG coverage-roadmap gap for task-list checkbox click.
+- Typing `:` at a word boundary in Visual Edit (and the source editor) opens a slash-palette-like shortcode completer against the maintained emoji table; confirming inserts the canonical `:shortcode:` as one undoable edit.
+
+### Non-goals
+
+YAML front matter, indented/unclosed code, definition lists, malformed tables, reference-style images, math-failure islands, Typora `[TOC]`, emoji *character* insertion (source stays `:name:`), cloud emoji packs, auto-pair inside fenced-code / math / diagram payload editors, Read/Split Preview checkbox editing, and guessing rendered-tree mutations.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `markdown-editing`: Auto-pair, hide block markers when a Visual Edit row loses the caret, clickable task-list checkboxes, emoji `:` completer; close the task-checkbox roadmap gap.
+- `chrome-platform`: Persist and expose the Markdown auto-pair preference on Preferences → General.
+- `ui-i18n`: Localize the auto-pair preference, emoji palette chrome, and empty-match copy.
+
+## Impact
+
+- **Code:** Visual Edit / source text input (`src/app/editor_element.rs`, `src/app/editing.rs`, `src/app/preview.rs` list-item chrome); prefix-reveal gating; `src/parse.rs` `emoji_for_shortcode` (query API, possibly a larger static table); slash-palette-style overlay in `src/app/root_view.rs`; preferences in `config.toml` / General tab; `docs/visual-editing-quality.md` matrix/roadmap; `src/i18n.rs`.
+- **Invariants:** Every mutation is one canonical `MarkdownDocument.text` edit through the existing dirty/undo/autosave/recovery path. Showing, filtering, or dismissing auto-pair / emoji UI MUST NOT increment document version or invalidate per-version derived caches (`Arc` preview/visual/outline/stats). Syntax-highlight memoization and cached text handles stay intact. `crates/*` stay GPUI-free.
+- **Tests:** Pure pairing/skip/unwrap and shortcode-filter tests; Visual Edit GPUI tests for Enter-then-hidden prefixes, checkbox toggle + undo, emoji confirm/cancel/IME; preference round-trip; i18n exhaustiveness.

--- a/openspec/changes/add-visual-edit-typing-loop/specs/chrome-platform/spec.md
+++ b/openspec/changes/add-visual-edit-typing-loop/specs/chrome-platform/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Narrow-scope preferences with persistence and reset
+The editor SHALL provide a Preferences panel and a persisted preferences file covering: theme (and custom theme selection), focus mode, typewriter mode, code-line-numbers, sidebar visibility, sidebar tab, Heading menu depth (H1–H5 default, optional H1–H6), source-editor font size, rendered-document font size, rendered paragraph spacing, and Markdown auto-pair. The preferences file SHALL be TOML (`config.toml` in the Markion config directory) with every field optional and defaulted, and SHALL additionally carry an `[auto_save]` section (`enabled`, `delay_secs`) that is configurable only via the file, not the panel. On startup, if `config.toml` does not exist but a legacy `preferences.conf` (the retired `key=value` format) does, the editor SHALL migrate it to `config.toml` once and thereafter ignore the legacy file. The editor SHALL also offer a preference reset action and a preferences summary in the Help menu. Font family, code-highlight theme, extension-syntax toggles, and image-uploader credentials are **not** configurable.
+
+#### Scenario: Supported preferences persist and restore
+- **WHEN** the user changes a supported preference (theme, focus mode, typewriter mode, code line numbers, sidebar visibility, sidebar tab, Heading menu depth, source-editor font size, rendered-document font size, rendered paragraph spacing, or Markdown auto-pair)
+- **THEN** the change is written to `config.toml` and restored on the next launch
+
+#### Scenario: Legacy preferences file is migrated once
+- **WHEN** the editor starts with no `config.toml` but a legacy `preferences.conf` present
+- **THEN** the legacy values are loaded, written out as `config.toml`, and used; subsequent launches read only `config.toml`
+
+#### Scenario: Partial or missing config falls back to defaults
+- **WHEN** `config.toml` is missing, or present but omits fields
+- **THEN** missing values take their documented defaults and the editor starts normally
+- **AND** a missing `markdown_auto_pair` key defaults to enabled
+
+#### Scenario: Preferences summary and reset
+- **WHEN** the user opens the Help → preferences summary or triggers the reset action
+- **THEN** a summary including supported typography values and Markdown auto-pair is shown, or all preferences including typography and Markdown auto-pair (default on) are reset to their defaults
+
+## ADDED Requirements
+
+### Requirement: Markdown auto-pair is a General preference
+The Preferences panel General tab SHALL expose a Markdown auto-pair toggle. The choice SHALL persist as a boolean `markdown_auto_pair` in `config.toml` (default `true`; missing or non-boolean values degrade to `true`). Toggling SHALL apply to the next typed delimiter without restarting, SHALL NOT mutate document text or increment document version, and SHALL be restored by the preference reset action.
+
+#### Scenario: General tab shows the toggle
+- **WHEN** the Preferences panel is open on the General tab
+- **THEN** a Markdown auto-pair control is present and reflects the persisted value
+
+#### Scenario: Turning auto-pair off is immediate
+- **WHEN** the user disables Markdown auto-pair
+- **THEN** the next typed `*` in an editing surface inserts only `*`
+- **AND** document version and derived Markdown caches are unchanged by the preference change

--- a/openspec/changes/add-visual-edit-typing-loop/specs/markdown-editing/spec.md
+++ b/openspec/changes/add-visual-edit-typing-loop/specs/markdown-editing/spec.md
@@ -1,0 +1,153 @@
+## ADDED Requirements
+
+### Requirement: Markdown delimiter auto-pair on editing surfaces
+When Markdown auto-pair is enabled, typing an opening delimiter on the source editor, Visual Edit prose, or a Visual Edit table cell SHALL insert the matching closer and leave the caret between the pair; typing an opener over a non-empty selection SHALL wrap that selection; typing a closer whose next source character is already that closer SHALL move the caret past it without inserting; Backspace between an empty pair SHALL delete both characters. The paired openers SHALL be `*`, `_`, `` ` ``, `$`, `(`, `[`, `{`, `"`, and `'`. Pairing SHALL NOT run while an IME marked range is active, when the previous character is a backslash, or inside a fenced-code, block-math, or diagram payload editor. Pairing SHALL be one canonical source mutation through the existing dirty-state, undo/redo, autosave, and recovery path.
+
+#### Scenario: Typing an opener inserts a wrap pair
+- **WHEN** Markdown auto-pair is enabled and the user types `*` with an empty selection in Visual Edit prose or the source editor
+- **THEN** the source contains `**` at that offset with the caret between the two characters
+- **AND** one Undo removes both characters
+
+#### Scenario: A selection is wrapped
+- **WHEN** Markdown auto-pair is enabled and the user types `(` over a non-empty, exactly mapped selection
+- **THEN** the selected text is wrapped in `(` and `)`
+- **AND** the resulting selection stays on the wrapped content
+
+#### Scenario: Typing the closer skips an existing pair
+- **WHEN** the source after the caret is already the matching closer for the character just typed
+- **THEN** the editor moves the caret past that closer
+- **AND** it does not insert a second closer or bump derived caches beyond the caret move
+
+#### Scenario: Backspace unwraps an empty pair
+- **WHEN** the caret sits between a just-inserted empty pair and the user presses Backspace
+- **THEN** both the opener and closer are removed in one edit
+
+#### Scenario: Pairing is suppressed in code and during IME
+- **WHEN** the caret is inside a fenced-code, block-math, or diagram payload editor, or an IME composition is active
+- **THEN** typed `*` / `` ` `` / `$` insert only the typed character
+
+#### Scenario: Disabled preference types literally
+- **WHEN** Markdown auto-pair is off
+- **THEN** typing an opener inserts only that opener
+
+### Requirement: Unfocused Visual Edit block markers stay hidden after Enter
+When the Visual Edit caret leaves a heading, ordered or unordered list item, task-list item, or blockquote row — including by pressing Enter to start the next paragraph or list item — that row SHALL hide its structural Markdown prefixes (`#`–`######`, list/task markers, `>`) and present the rendered form (heading typography, list/task glyph, quote bar). Hiding prefixes SHALL NOT rewrite `MarkdownDocument.text`. A line whose source is a just-typed ATX, list, task, or quote prefix (with optional heading title text) SHALL be classified as that block on the next derivation so the unfocused row does not keep the marker characters as visible prose. Focusing the row SHALL still reveal the prefix through the existing progressive-reveal mapping.
+
+#### Scenario: Enter after a heading hides the hashes
+- **WHEN** the Visual Edit caret is in an ATX heading and the user presses Enter, producing a following paragraph
+- **THEN** the heading row paints without visible `#` markers
+- **AND** the heading source still contains those hashes
+- **AND** moving the caret back onto the heading reveals the prefix
+
+#### Scenario: Enter after a list item hides the previous marker source
+- **WHEN** the caret is in a non-empty list or task item and the user presses Enter to continue the list
+- **THEN** the previous item shows the rendered bullet, number, or checkbox glyph rather than `- ` / `1. ` / `- [ ]`
+- **AND** the new item may reveal its prefix while it owns the caret
+
+#### Scenario: Typed heading prefix becomes a heading, not leftover prose
+- **WHEN** the user types `## Title` at the start of a Visual Edit paragraph and presses Enter
+- **THEN** the previous row is a heading whose unfocused presentation hides `##`
+- **AND** the following row is a paragraph
+
+#### Scenario: Caret leave without Enter also hides prefixes
+- **WHEN** the user clicks another Visual Edit row so a heading or list row no longer owns the caret
+- **THEN** that row hides its structural prefixes
+- **AND** document version, dirty state, and derived Markdown caches are unchanged
+
+### Requirement: Visual Edit task-list checkboxes are clickable
+In Visual Edit, an unfocused (prefix-hidden) task-list item SHALL present its checkbox glyph as a pointer target. Activating that glyph SHALL toggle the item's canonical task marker between `[ ]` and `[x]` as one exact source mutation, preserving the item text, list indentation, and surrounding source. `[X]` SHALL toggle off to `[ ]`. The click SHALL NOT run when the task prefix is revealed as source, SHALL NOT edit Read or Split Preview, and SHALL NOT bump document version if the pointer misses the glyph. Showing the glyph and hovering it SHALL NOT mutate the document.
+
+#### Scenario: Clicking an unchecked box checks it
+- **WHEN** a Visual Edit task item is unchecked and its checkbox glyph is visible
+- **AND** the user primary-clicks that glyph
+- **THEN** the source marker at that item becomes `[x]`
+- **AND** one Undo restores `[ ]`
+
+#### Scenario: Clicking a checked box unchecks it
+- **WHEN** a Visual Edit task item is checked (`[x]` or `[X]`) and the user primary-clicks its checkbox glyph
+- **THEN** the source marker becomes `[ ]`
+
+#### Scenario: Revealed source marker is not a toggle hit target
+- **WHEN** the caret is in a task item so `- [ ]` / `- [x]` is revealed
+- **THEN** clicking inside the revealed prefix edits or places the caret in source
+- **AND** it does not perform a separate checkbox-toggle mutation
+
+#### Scenario: Read and Split Preview stay inert
+- **WHEN** the user clicks a task-list checkbox glyph in Read mode or Split Preview
+- **THEN** the document text, dirty state, and undo history are unchanged
+
+### Requirement: Colon emoji shortcode completion
+When the user types `:` at a word boundary (start of line, whitespace, or opening punctuation) on the source editor or Visual Edit prose, outside fenced-code / math / diagram payloads and outside an IME composition, the editor SHALL open a localized shortcode palette filtered by the ASCII prefix after that colon against the maintained emoji shortcode table. Confirming a row (Enter, Tab, or pointer) SHALL replace the open `:query` with the canonical `:name:` (including the closing colon) as one undoable source edit; the preview and unfocused Visual Edit SHALL render the matching emoji glyph through the existing shortcode parser. Escape or moving the caret so the token is no longer an open shortcode SHALL dismiss the palette without writing. Opening, filtering, moving the highlight, and dismissing SHALL NOT increment document version. If a slash-command palette is already open for a `/` query, that palette SHALL take priority and this completer SHALL NOT open.
+
+#### Scenario: Colon at a word boundary opens the palette
+- **WHEN** the user types `:smi` in Visual Edit prose after a space
+- **THEN** a palette lists shortcodes whose names start with `smi` (for example `smile`)
+- **AND** document version is unchanged until a row is confirmed
+
+#### Scenario: Confirm inserts the shortcode
+- **WHEN** the palette is open on `smile` and the user confirms
+- **THEN** the source at that token is `:smile:`
+- **AND** unfocused Visual Edit and preview render the smile emoji
+- **AND** one Undo restores the text from before the confirmation
+
+#### Scenario: Escape dismisses without writing
+- **WHEN** the emoji palette is open and the user presses Escape
+- **THEN** the palette closes
+- **AND** the authored `:query` remains as typed
+- **AND** document version is unchanged by the dismiss
+
+#### Scenario: Time and URLs do not open the palette
+- **WHEN** the user types `12:30` or `https://example.com`
+- **THEN** the emoji palette does not open
+
+#### Scenario: Slash commands win on a slash query
+- **WHEN** the slash-command palette is open because the line starts with `/`
+- **THEN** typing `:` inside that query does not open the emoji palette
+
+## MODIFIED Requirements
+
+### Requirement: Maintained Visual Edit support classification
+The repository SHALL maintain a current Visual Edit WYSIWYG coverage matrix that classifies every user-visible Markdown construct into exactly one of three classes: **rendered WYSIWYG** (the construct is shown in its rendered form, including dedicated field/payload editors for code, math, diagrams, images, and tables whose editors ARE the rendered form), **progressive-reveal WYSIWYG** (the construct is rendered by default and reveals its smallest complete source syntax group when the caret enters it — inline formatting, links, inline math, structural prefixes), or **WYSIWYG coverage gap** (the construct currently shows raw source and is tracked under the `WYSIWYG coverage roadmap` for closure by a future change). The matrix SHALL name the canonical editable range and the verification evidence for each rendered/reveal class, and SHALL name the roadmap priority and implementation seam for each gap. The matrix SHALL agree with the stable requirements and the implemented `VisualBlock`/`VisualBlockEditor` behavior.
+
+#### Scenario: Contributor evaluates current WYSIWYG coverage
+- **WHEN** a contributor reads the Visual Edit WYSIWYG coverage matrix
+- **THEN** it distinguishes rendered WYSIWYG constructs (prose, code, math, diagrams, images, tables, task lists including clickable Visual Edit checkboxes, footnote definitions and references, blockquotes, alerts, rules, HTML blocks), progressive-reveal WYSIWYG constructs (inline formatting, links, inline math, escaped punctuation, supported inline HTML, structural prefixes, heading attributes), and open WYSIWYG gaps (decoded entities, front matter, indented code, unclosed fences, reference-style images, malformed tables, unsupported inline-HTML forms, autolinks, definition lists, empty list items)
+- **AND** it explains that canonical Markdown remains the single persisted representation and that no construct is edited through a parallel rendered tree
+
+#### Scenario: A new visual block behavior is proposed
+- **WHEN** a proposal changes how a Markdown construct is presented or edited in Visual Edit
+- **THEN** the proposal selects one of the three coverage classes for the construct
+- **AND** if the proposal moves a construct out of the gap class, it updates the matrix and the `WYSIWYG coverage roadmap`
+- **AND** implementation and documentation cannot be considered complete until the matrix and invariant evidence are updated
+
+### Requirement: WYSIWYG coverage roadmap
+The repository SHALL maintain, as part of the Visual Edit WYSIWYG coverage matrix, a prioritized roadmap of every Markdown construct that is currently classified as a WYSIWYG coverage gap. The roadmap SHALL name, for each gap, the construct, its current rendering (transitional source view), its target WYSIWYG class (rendered or progressive-reveal), its priority, its rough implementation effort, and the implementation seam in the existing code. The roadmap SHALL be closed incrementally by future changes, each of which SHALL move one or more constructs out of the gap class and update this roadmap. The initial roadmap SHALL include at minimum the following primary gaps in priority order: (1) decoded HTML entities in prose blocks (for example `&amp;`), (2) front matter (an editing form for YAML `---` regions, and detection of TOML/JSON forms), and (3) indented code blocks. The roadmap SHALL also track secondary gaps including unclosed or malformed fenced code, reference-style and malformed inline images, malformed tables, unsupported inline-HTML forms and angle-bracket autolinks in prose, GFM definition lists, empty list items, and math render-failure states. Task-list checkbox click interaction SHALL NOT remain on the roadmap once Visual Edit checkboxes are clickable.
+
+#### Scenario: Primary gaps are tracked with priority and effort
+- **WHEN** a contributor reads the WYSIWYG coverage roadmap
+- **THEN** the current primary gaps (decoded HTML entities, front matter, indented code blocks) are listed with priority, effort, target class, and implementation seam
+- **AND** each primary gap points at the source location of the current transitional source-view rendering
+
+#### Scenario: Closing a gap updates the roadmap
+- **WHEN** a future change implements WYSIWYG rendering for a construct that the roadmap tracks as a gap
+- **THEN** that change's spec delta moves the construct out of the gap class in the `Maintained Visual Edit support classification` matrix and removes it from this roadmap
+- **AND** the change's proposal cites this roadmap requirement as its motivation
+
+#### Scenario: Closed gaps do not regress
+- **WHEN** a construct previously tracked as a gap has been implemented as rendered or progressive-reveal WYSIWYG (for example escaped punctuation, the supported inline-HTML subset, standalone HTML blocks, reference-style links, inline-dollar math, footnote and link-reference definitions, heading attributes, GFM alerts, or Visual Edit task-list checkbox click)
+- **THEN** the coverage matrix classifies the construct in its implemented class and the construct does not reappear on the roadmap
+
+#### Scenario: Secondary gaps are visible but lower priority
+- **WHEN** a contributor evaluates whether to pick up a secondary gap (for example angle-bracket autolinks)
+- **THEN** the roadmap lists the secondary gap with its effort and implementation seam
+- **AND** the contributor can open a change that closes it without re-litigating whether it is a gap
+
+#### Scenario: New gaps discovered in implementation are added to the roadmap
+- **WHEN** implementation or testing reveals a Markdown construct that renders as raw source in Visual Edit and is not yet on the roadmap
+- **THEN** the discovering change SHALL add the construct to this roadmap with its class, priority, effort, and seam before completing
+- **AND** the change SHALL NOT close the gap in the same change unless the gap is trivial
+
+#### Scenario: Task-list checkbox click is a closed gap
+- **WHEN** a contributor reads the WYSIWYG coverage roadmap after this change
+- **THEN** task-list checkbox click is absent from the open-gap list
+- **AND** the coverage matrix records clickable Visual Edit task checkboxes as rendered WYSIWYG

--- a/openspec/changes/add-visual-edit-typing-loop/specs/ui-i18n/spec.md
+++ b/openspec/changes/add-visual-edit-typing-loop/specs/ui-i18n/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Typing-loop chrome is localized
+Every user-visible string introduced for Markdown auto-pair and emoji shortcode completion SHALL go through the i18n layer (`t` / `tf` and exhaustive per-language `Msg` arms): the Preferences → General auto-pair label and any helper copy, the emoji palette title, empty-match copy, and row labels that are not the raw `:shortcode:` token. Hard-coded English literals SHALL NOT remain on those surfaces. Changing the interface language SHALL relabel an open emoji palette and the auto-pair control without mutating the document.
+
+#### Scenario: Auto-pair label follows the interface language
+- **WHEN** the active interface language is Simplified Chinese and Preferences → General is open
+- **THEN** the Markdown auto-pair control label is the Simplified Chinese string from the i18n module
+
+#### Scenario: Emoji palette chrome follows the interface language
+- **WHEN** the emoji shortcode palette is open and the interface language is Japanese
+- **THEN** the palette title and empty-match copy are Japanese via the i18n module
+- **AND** shortcode names remain the ASCII `:name:` tokens
+
+#### Scenario: Language switch does not edit the document
+- **WHEN** the user changes the interface language while the emoji palette is open
+- **THEN** palette chrome relabels
+- **AND** document version, dirty state, and undo history are unchanged

--- a/openspec/changes/add-visual-edit-typing-loop/tasks.md
+++ b/openspec/changes/add-visual-edit-typing-loop/tasks.md
@@ -1,29 +1,29 @@
 ## 1. Auto-pair preference
 
-- [ ] 1.1 Add `markdown_auto_pair: bool` (default `true`) to `AppPreferences` / `PreferencesFile`, tolerate missing or non-boolean as `true`, include it in reset, and verify preference load/save/reset tests cover the new key
-- [ ] 1.2 Expose a General-tab toggle wired through i18n in all seven languages, and verify toggling does not increment document version while `cargo test` preference/i18n cases pass
+- [x] 1.1 Add `markdown_auto_pair: bool` (default `true`) to `AppPreferences` / `PreferencesFile`, tolerate missing or non-boolean as `true`, include it in reset, and verify preference load/save/reset tests cover the new key
+- [x] 1.2 Expose a General-tab toggle wired through i18n in all seven languages, and verify toggling does not increment document version while `cargo test` preference/i18n cases pass
 
 ## 2. Markdown auto-pair
 
-- [ ] 2.1 Implement opener/wrap/skip-closer/Backspace-unwrap for `*`, `_`, `` ` ``, `$`, `(`, `[`, `{`, `"`, `'` at the shared text-input boundary, skipping IME marked ranges, backslash-escaped characters, and fenced-code / math / diagram payload editors, and verify pure tests for pair, wrap, skip, unwrap, and suppression
-- [ ] 2.2 Honor `markdown_auto_pair` on the source editor, Visual Edit prose, and Visual Edit table cells, and verify GPUI or document tests that a typed `*` with the preference off inserts only `*` and that one Undo reverses a pair
+- [x] 2.1 Implement opener/wrap/skip-closer/Backspace-unwrap for `*`, `_`, `` ` ``, `$`, `(`, `[`, `{`, `"`, `'` at the shared text-input boundary, skipping IME marked ranges, backslash-escaped characters, and fenced-code / math / diagram payload editors, and verify pure tests for pair, wrap, skip, unwrap, and suppression
+- [x] 2.2 Honor `markdown_auto_pair` on the source editor, Visual Edit prose, and Visual Edit table cells, and verify GPUI or document tests that a typed `*` with the preference off inserts only `*` and that one Undo reverses a pair
 
 ## 3. Hide block markers after Enter
 
-- [ ] 3.1 Assert unfocused heading/list/task/quote rows hide structural prefixes after Enter or a caret move, without rewriting source, and verify Visual Edit tests for `## Title` + Enter, list continue, and click-away (version-stable hide)
-- [ ] 3.2 If a just-typed ATX/list/task/quote line still paints marker characters as prose when unfocused, fix classification/projection so the next derivation shows the rendered row, and verify the typed-heading scenario in the markdown-editing delta
+- [x] 3.1 Assert unfocused heading/list/task/quote rows hide structural prefixes after Enter or a caret move, without rewriting source, and verify Visual Edit tests for `## Title` + Enter, list continue, and click-away (version-stable hide)
+- [x] 3.2 If a just-typed ATX/list/task/quote line still paints marker characters as prose when unfocused, fix classification/projection so the next derivation shows the rendered row, and verify the typed-heading scenario in the markdown-editing delta
 
 ## 4. Clickable task-list checkboxes
 
-- [ ] 4.1 Hit-test the Visual Edit task glyph column and toggle `[ ]` ↔ `[x]` (`[X]` off → `[ ]`) as one checked source mutation when the prefix is hidden, and verify model/GPUI tests for check, uncheck, undo, and revealed-prefix click-through
-- [ ] 4.2 Leave Read and Split Preview checkboxes inert, and verify pointer tests on those surfaces do not dirty the document
-- [ ] 4.3 Close roadmap gap 7 in `docs/visual-editing-quality.md` (clickable checkbox = rendered WYSIWYG) and verify the matrix no longer lists task-list checkbox click as an open gap
+- [x] 4.1 Hit-test the Visual Edit task glyph column and toggle `[ ]` ↔ `[x]` (`[X]` off → `[ ]`) as one checked source mutation when the prefix is hidden, and verify model/GPUI tests for check, uncheck, undo, and revealed-prefix click-through
+- [x] 4.2 Leave Read and Split Preview checkboxes inert, and verify pointer tests on those surfaces do not dirty the document
+- [x] 4.3 Close roadmap gap 7 in `docs/visual-editing-quality.md` (clickable checkbox = rendered WYSIWYG) and verify the matrix no longer lists task-list checkbox click as an open gap
 
 ## 5. Emoji `:` completer
 
-- [ ] 5.1 Expose a GPUI-free queryable shortcode table from the existing `emoji_for_shortcode` set (modest common-name expansion allowed), and verify prefix-filter unit tests including empty/no-match and charset rules
-- [ ] 5.2 Add per-tab emoji-query state and a slash-palette-like overlay (i18n title/empty copy) that opens on word-boundary `:`, ignores `12:30` / `://`, yields to an open slash palette, and dismisses on Escape without a version bump, verified by GPUI/state tests
-- [ ] 5.3 Confirm (Enter/Tab/click) replaces `:query` with `:name:` as one undoable edit so preview/Visual Edit render the glyph, and verify undo plus IME-composition suppression tests
+- [x] 5.1 Expose a GPUI-free queryable shortcode table from the existing `emoji_for_shortcode` set (modest common-name expansion allowed), and verify prefix-filter unit tests including empty/no-match and charset rules
+- [x] 5.2 Add per-tab emoji-query state and a slash-palette-like overlay (i18n title/empty copy) that opens on word-boundary `:`, ignores `12:30` / `://`, yields to an open slash palette, and dismisses on Escape without a version bump, verified by GPUI/state tests
+- [x] 5.3 Confirm (Enter/Tab/click) replaces `:query` with `:name:` as one undoable edit so preview/Visual Edit render the glyph, and verify undo plus IME-composition suppression tests
 
 ## 6. Verification
 

--- a/openspec/changes/add-visual-edit-typing-loop/tasks.md
+++ b/openspec/changes/add-visual-edit-typing-loop/tasks.md
@@ -27,5 +27,5 @@
 
 ## 6. Verification
 
-- [ ] 6.1 Run `cargo fmt --check` and `cargo test --workspace`, fixing pairing, checkbox, emoji, preference, or i18n regressions while leaving per-version `Arc` derived caches untouched on interaction-only paths
-- [ ] 6.2 Run `openspec validate add-visual-edit-typing-loop` and reconcile tasks with the proposal, design, and delta specs
+- [x] 6.1 Run `cargo fmt --check` and `cargo test --workspace`, fixing pairing, checkbox, emoji, preference, or i18n regressions while leaving per-version `Arc` derived caches untouched on interaction-only paths
+- [x] 6.2 Run `openspec validate add-visual-edit-typing-loop` and reconcile tasks with the proposal, design, and delta specs

--- a/openspec/changes/add-visual-edit-typing-loop/tasks.md
+++ b/openspec/changes/add-visual-edit-typing-loop/tasks.md
@@ -1,0 +1,31 @@
+## 1. Auto-pair preference
+
+- [ ] 1.1 Add `markdown_auto_pair: bool` (default `true`) to `AppPreferences` / `PreferencesFile`, tolerate missing or non-boolean as `true`, include it in reset, and verify preference load/save/reset tests cover the new key
+- [ ] 1.2 Expose a General-tab toggle wired through i18n in all seven languages, and verify toggling does not increment document version while `cargo test` preference/i18n cases pass
+
+## 2. Markdown auto-pair
+
+- [ ] 2.1 Implement opener/wrap/skip-closer/Backspace-unwrap for `*`, `_`, `` ` ``, `$`, `(`, `[`, `{`, `"`, `'` at the shared text-input boundary, skipping IME marked ranges, backslash-escaped characters, and fenced-code / math / diagram payload editors, and verify pure tests for pair, wrap, skip, unwrap, and suppression
+- [ ] 2.2 Honor `markdown_auto_pair` on the source editor, Visual Edit prose, and Visual Edit table cells, and verify GPUI or document tests that a typed `*` with the preference off inserts only `*` and that one Undo reverses a pair
+
+## 3. Hide block markers after Enter
+
+- [ ] 3.1 Assert unfocused heading/list/task/quote rows hide structural prefixes after Enter or a caret move, without rewriting source, and verify Visual Edit tests for `## Title` + Enter, list continue, and click-away (version-stable hide)
+- [ ] 3.2 If a just-typed ATX/list/task/quote line still paints marker characters as prose when unfocused, fix classification/projection so the next derivation shows the rendered row, and verify the typed-heading scenario in the markdown-editing delta
+
+## 4. Clickable task-list checkboxes
+
+- [ ] 4.1 Hit-test the Visual Edit task glyph column and toggle `[ ]` ↔ `[x]` (`[X]` off → `[ ]`) as one checked source mutation when the prefix is hidden, and verify model/GPUI tests for check, uncheck, undo, and revealed-prefix click-through
+- [ ] 4.2 Leave Read and Split Preview checkboxes inert, and verify pointer tests on those surfaces do not dirty the document
+- [ ] 4.3 Close roadmap gap 7 in `docs/visual-editing-quality.md` (clickable checkbox = rendered WYSIWYG) and verify the matrix no longer lists task-list checkbox click as an open gap
+
+## 5. Emoji `:` completer
+
+- [ ] 5.1 Expose a GPUI-free queryable shortcode table from the existing `emoji_for_shortcode` set (modest common-name expansion allowed), and verify prefix-filter unit tests including empty/no-match and charset rules
+- [ ] 5.2 Add per-tab emoji-query state and a slash-palette-like overlay (i18n title/empty copy) that opens on word-boundary `:`, ignores `12:30` / `://`, yields to an open slash palette, and dismisses on Escape without a version bump, verified by GPUI/state tests
+- [ ] 5.3 Confirm (Enter/Tab/click) replaces `:query` with `:name:` as one undoable edit so preview/Visual Edit render the glyph, and verify undo plus IME-composition suppression tests
+
+## 6. Verification
+
+- [ ] 6.1 Run `cargo fmt --check` and `cargo test --workspace`, fixing pairing, checkbox, emoji, preference, or i18n regressions while leaving per-version `Arc` derived caches untouched on interaction-only paths
+- [ ] 6.2 Run `openspec validate add-visual-edit-typing-loop` and reconcile tasks with the proposal, design, and delta specs

--- a/src/app/appearance.rs
+++ b/src/app/appearance.rs
@@ -134,6 +134,7 @@ impl MarkionApp {
                     app.heading_menu_max_level = preferences.heading_menu_max_level;
                     app.sync_scroll = preferences.sync_scroll;
                     app.open_in_current_tab = preferences.open_in_current_tab;
+                    app.markdown_auto_pair = preferences.markdown_auto_pair;
                     app.sidebar_visible = preferences.sidebar_visible;
                     app.sidebar_tab = preferences.sidebar_tab;
                     app.auto_save_preferences = preferences.auto_save;
@@ -489,6 +490,21 @@ impl MarkionApp {
                 Msg::StatusOpenInCurrentTabOn
             } else {
                 Msg::StatusOpenInCurrentTabOff
+            },
+        )
+        .into();
+        self.persist_preferences();
+        cx.notify();
+    }
+
+    pub(super) fn toggle_markdown_auto_pair(&mut self, cx: &mut Context<Self>) {
+        self.markdown_auto_pair = !self.markdown_auto_pair;
+        self.status = t(
+            self.language,
+            if self.markdown_auto_pair {
+                Msg::StatusMarkdownAutoPairOn
+            } else {
+                Msg::StatusMarkdownAutoPairOff
             },
         )
         .into();

--- a/src/app/application.rs
+++ b/src/app/application.rs
@@ -236,6 +236,7 @@ impl MarkionApp {
             sync_scroll: preferences.sync_scroll,
             show_hidden_files: preferences.show_hidden_files,
             open_in_current_tab: preferences.open_in_current_tab,
+            markdown_auto_pair: preferences.markdown_auto_pair,
             language: Language::from_code(&preferences.language),
             check_for_updates_on_startup: preferences.check_for_updates_on_startup,
             last_update_check: preferences.last_update_check,
@@ -272,6 +273,8 @@ impl MarkionApp {
             recovery_manager: None,
             slash_commands: None,
             dismissed_slash_query: None,
+            emoji_completer: None,
+            dismissed_emoji_query: None,
             block_menu: None,
             search_visible: false,
             replace_visible: false,
@@ -383,6 +386,8 @@ impl MarkionApp {
         self.tab_context_menu = None;
         self.slash_commands = None;
         self.dismissed_slash_query = None;
+        self.emoji_completer = None;
+        self.dismissed_emoji_query = None;
         self.dismiss_visual_block_menu();
         if self.active_tab().is_image() {
             self.search_visible = false;
@@ -766,6 +771,8 @@ impl MarkionApp {
         }
         self.slash_commands = None;
         self.dismissed_slash_query = None;
+        self.emoji_completer = None;
+        self.dismissed_emoji_query = None;
         self.dismiss_visual_block_menu();
         let tab = self.active_tab_mut();
         tab.clear_visual_caret_affinity();
@@ -879,6 +886,8 @@ impl MarkionApp {
         self.input_marked_len = 0;
         self.slash_commands = None;
         self.dismissed_slash_query = None;
+        self.emoji_completer = None;
+        self.dismissed_emoji_query = None;
         self.dismiss_visual_block_menu();
         self.status = p0_t(self.language, P0Msg::IntegrityMutationRejected).into();
     }
@@ -1921,6 +1930,7 @@ impl MarkionApp {
             sync_scroll: self.sync_scroll,
             show_hidden_files: self.show_hidden_files,
             open_in_current_tab: self.open_in_current_tab,
+            markdown_auto_pair: self.markdown_auto_pair,
             sidebar_visible: self.sidebar_visible,
             sidebar_tab: self.sidebar_tab,
             language: self.language.code().to_string(),

--- a/src/app/editing.rs
+++ b/src/app/editing.rs
@@ -176,6 +176,164 @@ impl MarkionApp {
         }
     }
 
+    pub(super) fn sync_emoji_completer_state(&mut self, cx: &mut Context<Self>) {
+        if self.slash_commands.is_some() {
+            if self.emoji_completer.take().is_some() {
+                cx.notify();
+            }
+            return;
+        }
+        let query = if self.link_editor.is_none()
+            && matches!(self.view_mode, ViewMode::Edit | ViewMode::VisualEdit)
+            && self.active_tab().selected_range.is_empty()
+            && self.active_tab().marked_range.is_none()
+        {
+            let tab = self.active_tab();
+            let caret = tab.cursor_offset();
+            let restricted = tab
+                .document
+                .visual_editor_field_at(&(caret..caret))
+                .is_some_and(|field| is_auto_pair_restricted_field(field.kind));
+            if restricted {
+                None
+            } else {
+                emoji_query_at(tab.document.text(), caret, tab.document.version())
+            }
+        } else {
+            None
+        };
+        let Some(query) = query else {
+            if self.emoji_completer.take().is_some() {
+                cx.notify();
+            }
+            return;
+        };
+        if self.dismissed_emoji_query.as_ref() == Some(&query) {
+            if self.emoji_completer.take().is_some() {
+                cx.notify();
+            }
+            return;
+        }
+        self.dismissed_emoji_query = None;
+        let count = emoji_shortcodes_matching(&query.query).len();
+        if let Some(state) = &mut self.emoji_completer
+            && state.query == query
+        {
+            state.selected = state.selected.min(count.saturating_sub(1));
+            return;
+        }
+        self.emoji_completer = Some(EmojiCompleterState { query, selected: 0 });
+        cx.notify();
+    }
+
+    pub(super) fn move_emoji_selection(&mut self, forward: bool, cx: &mut Context<Self>) -> bool {
+        let Some(state) = &mut self.emoji_completer else {
+            return false;
+        };
+        let count = emoji_shortcodes_matching(&state.query.query)
+            .len()
+            .min(EMOJI_PALETTE_LIMIT);
+        if count == 0 {
+            return true;
+        }
+        state.selected = if forward {
+            (state.selected + 1) % count
+        } else if state.selected == 0 {
+            count - 1
+        } else {
+            state.selected - 1
+        };
+        cx.notify();
+        true
+    }
+
+    pub(super) fn confirm_selected_emoji(&mut self, cx: &mut Context<Self>) -> bool {
+        let Some(state) = self.emoji_completer.clone() else {
+            return false;
+        };
+        let matches: Vec<_> = emoji_shortcodes_matching(&state.query.query)
+            .into_iter()
+            .take(EMOJI_PALETTE_LIMIT)
+            .collect();
+        let Some((name, _)) = matches.get(state.selected).copied() else {
+            return true;
+        };
+        self.execute_emoji_completion(state.query, name, cx);
+        true
+    }
+
+    pub(super) fn execute_emoji_completion(
+        &mut self,
+        query: EmojiQuery,
+        name: &str,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(replacement) = emoji_confirm_replacement(name) else {
+            return;
+        };
+        let end = query.source_range.start + replacement.len();
+        self.apply_exact_block_edit(
+            BlockEdit {
+                document_version: query.document_version,
+                range: query.source_range,
+                replacement,
+                selection_after: end..end,
+            },
+            p1_t(self.language, P1Msg::EmojiShortcodes).into(),
+            cx,
+        );
+    }
+
+    pub(super) fn toggle_visual_task_checkbox(
+        &mut self,
+        block_index: usize,
+        cx: &mut Context<Self>,
+    ) {
+        if !matches!(self.view_mode, ViewMode::VisualEdit) {
+            return;
+        }
+        let tab = self.active_tab();
+        let blocks = tab.document.visual_blocks_shared();
+        let Some(block) = blocks.get(block_index) else {
+            return;
+        };
+        let Some(prefix) = block.block_prefix.clone() else {
+            return;
+        };
+        let cursor = tab.cursor_offset();
+        let prefix_revealed = prefix.source_range.contains(&cursor)
+            || cursor == prefix.source_range.end
+            || (block.editable_runs.is_empty()
+                && (block.source_range.contains(&cursor) || cursor == block.source_range.end));
+        if prefix_revealed {
+            return;
+        }
+        let Some((range, replacement)) = task_checkbox_toggle(tab.document.text(), &prefix) else {
+            return;
+        };
+        let caret = prefix.source_range.end;
+        self.push_undo_snapshot();
+        let mutation = {
+            let tab = self.active_tab_mut();
+            tab.document
+                .prepare_range_mutation(MutationOrigin::StructuralEdit, range, &replacement)
+        };
+        if self
+            .apply_document_mutation("toggle_task_checkbox", mutation)
+            .is_none()
+        {
+            cx.notify();
+            return;
+        }
+        let tab = self.active_tab_mut();
+        tab.selected_range = caret..caret;
+        tab.selection_reversed = false;
+        tab.marked_range = None;
+        self.status = t(self.language, Msg::StatusEditing).into();
+        self.after_document_changed(cx);
+        cx.notify();
+    }
+
     pub(super) fn open_visual_block_menu(
         &mut self,
         target: BlockTarget,
@@ -208,6 +366,7 @@ impl MarkionApp {
             submenu_selected: 0,
         });
         self.slash_commands = None;
+        self.emoji_completer = None;
         self.preview_context_menu = None;
         self.file_tree_context_menu = None;
         self.tab_context_menu = None;
@@ -645,6 +804,8 @@ impl MarkionApp {
         tab.marked_range = None;
         self.slash_commands = None;
         self.dismissed_slash_query = None;
+        self.emoji_completer = None;
+        self.dismissed_emoji_query = None;
         self.dismiss_visual_block_menu();
         self.status = status;
         self.after_document_changed(cx);
@@ -654,6 +815,8 @@ impl MarkionApp {
     fn report_block_edit_error(&mut self, error: BlockEditError, cx: &mut Context<Self>) {
         self.slash_commands = None;
         self.dismissed_slash_query = None;
+        self.emoji_completer = None;
+        self.dismissed_emoji_query = None;
         self.dismiss_visual_block_menu();
         self.status = p1_t(
             self.language,
@@ -2118,6 +2281,9 @@ impl MarkionApp {
         if self.move_slash_selection(false, cx) {
             return;
         }
+        if self.move_emoji_selection(false, cx) {
+            return;
+        }
         if self.move_visual_vertical(VisualNavigationDirection::Up, false, cx) {
             return;
         }
@@ -2140,6 +2306,9 @@ impl MarkionApp {
         }
         self.sync_slash_command_state(cx);
         if self.move_slash_selection(true, cx) {
+            return;
+        }
+        if self.move_emoji_selection(true, cx) {
             return;
         }
         if self.move_visual_vertical(VisualNavigationDirection::Down, false, cx) {
@@ -2263,6 +2432,10 @@ impl MarkionApp {
         }
         self.sync_slash_command_state(cx);
         if self.confirm_selected_slash_command(cx) {
+            return;
+        }
+        self.sync_emoji_completer_state(cx);
+        if self.confirm_selected_emoji(cx) {
             return;
         }
         let selected = self.active_tab().selected_range.clone();
@@ -2396,6 +2569,10 @@ impl MarkionApp {
         }
         if self.search_visible && self.search_control_focus.is_some() {
             self.cycle_search_overlay_focus(true, cx);
+            return;
+        }
+        self.sync_emoji_completer_state(cx);
+        if self.confirm_selected_emoji(cx) {
             return;
         }
         let selected = self.active_tab().selected_range.clone();

--- a/src/app/editing.rs
+++ b/src/app/editing.rs
@@ -311,8 +311,8 @@ impl MarkionApp {
         let Some((range, replacement)) = task_checkbox_toggle(tab.document.text(), &prefix) else {
             return;
         };
-        let caret = prefix.source_range.end;
-        self.push_undo_snapshot();
+        self.active_tab_mut().finish_undo_capture();
+        let snapshot = self.snapshot();
         let mutation = {
             let tab = self.active_tab_mut();
             tab.document
@@ -325,9 +325,8 @@ impl MarkionApp {
             cx.notify();
             return;
         }
+        self.commit_undo_snapshot(snapshot);
         let tab = self.active_tab_mut();
-        tab.selected_range = caret..caret;
-        tab.selection_reversed = false;
         tab.marked_range = None;
         self.status = t(self.language, Msg::StatusEditing).into();
         self.after_document_changed(cx);

--- a/src/app/editor_element.rs
+++ b/src/app/editor_element.rs
@@ -193,6 +193,7 @@ impl EntityInputHandler for MarkionApp {
             cx.notify();
             return;
         }
+        let markdown_auto_pair = self.markdown_auto_pair;
         let tab = self.active_tab_mut();
         let mut range = range_utf16
             .as_ref()
@@ -208,7 +209,7 @@ impl EntityInputHandler for MarkionApp {
                 .document
                 .visual_editor_field_at(&range)
                 .is_some_and(|field| is_auto_pair_restricted_field(field.kind));
-        if self.markdown_auto_pair && !skip_ime_pair && !restricted_pair_field {
+        if markdown_auto_pair && !skip_ime_pair && !restricted_pair_field {
             match auto_pair_action(tab.document.text(), range.clone(), new_text) {
                 Some(AutoPairAction::Skip { caret }) => {
                     tab.selected_range = caret..caret;

--- a/src/app/editor_element.rs
+++ b/src/app/editor_element.rs
@@ -194,11 +194,41 @@ impl EntityInputHandler for MarkionApp {
             return;
         }
         let tab = self.active_tab_mut();
-        let range = range_utf16
+        let mut range = range_utf16
             .as_ref()
             .and_then(|range_utf16| tab.range_from_utf16(range_utf16))
             .or(active_marked_range.clone())
             .unwrap_or_else(|| tab.safe_selected_range());
+
+        let mut paired_text: Option<String> = None;
+        let mut pair_selection: Option<Range<usize>> = None;
+        let skip_ime_pair = active_marked_range.is_some() || committing_ime;
+        let restricted_pair_field = visual_edit
+            && tab
+                .document
+                .visual_editor_field_at(&range)
+                .is_some_and(|field| is_auto_pair_restricted_field(field.kind));
+        if self.markdown_auto_pair && !skip_ime_pair && !restricted_pair_field {
+            match auto_pair_action(tab.document.text(), range.clone(), new_text) {
+                Some(AutoPairAction::Skip { caret }) => {
+                    tab.selected_range = caret..caret;
+                    tab.selection_reversed = false;
+                    cx.notify();
+                    return;
+                }
+                Some(AutoPairAction::Replace {
+                    range: pair_range,
+                    replacement,
+                    selection_after,
+                }) => {
+                    range = pair_range;
+                    paired_text = Some(replacement);
+                    pair_selection = Some(selection_after);
+                }
+                None => {}
+            }
+        }
+        let new_text = paired_text.as_deref().unwrap_or(new_text);
 
         let direct_edit = visual_edit
             .then(|| {
@@ -295,10 +325,17 @@ impl EntityInputHandler for MarkionApp {
             }
         }
         let tab = self.active_tab_mut();
-        tab.selected_range = direct_edit.as_ref().map_or_else(
-            || range.start + replacement.len()..range.start + replacement.len(),
-            |edit| edit.selection_after.clone(),
-        );
+        tab.selected_range = match (pair_selection, direct_edit.as_ref()) {
+            (Some(sel), Some(edit)) => {
+                let opener_len = sel.start.saturating_sub(range.start);
+                let inner_len = sel.end.saturating_sub(sel.start);
+                let start = edit.inserted_range_after.start + opener_len;
+                start..start + inner_len
+            }
+            (Some(sel), None) => sel,
+            (None, Some(edit)) => edit.selection_after.clone(),
+            (None, None) => range.start + replacement.len()..range.start + replacement.len(),
+        };
         tab.marked_range.take();
         if committing_ime {
             tab.finish_undo_capture();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -28,43 +28,45 @@ use gpui::{
 };
 use markion::i18n::{GitMsg, git_t, git_tf};
 use markion::{
-    AlertKind, AppPreferences, AutoSavePreferences, BlockEdit, BlockEditError, BlockPlacement,
-    BlockTarget, BlockTransform, CheckedMutation, CodeTheme, DEFAULT_CODE_FONT_FAMILY,
-    DEFAULT_EDITOR_FONT_SIZE, DEFAULT_EDITOR_SPLIT_RATIO, DEFAULT_HEADING_MENU_MAX_LEVEL,
-    DEFAULT_RENDERED_FONT_SIZE, DEFAULT_SIDEBAR_WIDTH, DiskIdentity, DiskState, DocumentInstanceId,
-    DocxImagePolicy, DocxPageSize, EXTENDED_HEADING_MENU_MAX_LEVEL, ExportBackendPreference,
-    ExportFormat, ExportPreferences, ExternalCheckOutcome, FileTree, FileTreeEntry,
-    FileTreeEntryKind, GitPreferences, HighlightKind, HighlightedSpan, HtmlAlign,
-    HtmlImageDescriptor, HtmlImgLength, HtmlListMarker, HtmlPreviewPart, HtmlTableGrid,
-    ImageAlignment, ImagePresentation, ImageSourceIdentity, InlineSpan, InlineStyle, Language,
-    MAX_AUTO_SAVE_DELAY_SECS, MAX_CODE_FONT_SIZE, MAX_EDITOR_FONT_SIZE, MAX_PARAGRAPH_SPACING,
-    MAX_RENDERED_FONT_SIZE, MIN_AUTO_SAVE_DELAY_SECS, MIN_CODE_FONT_SIZE, MIN_EDITOR_FONT_SIZE,
-    MIN_PARAGRAPH_SPACING, MIN_RENDERED_FONT_SIZE, MarkdownDocument, MarkdownFormat,
-    MathLayoutStyle, Msg, MutationOrigin, MutationReceipt, OrganizeCandidate, P0Msg, P1Msg,
-    PdfPageSize, PreviewBlock, RecoveryInventoryEntry, RecoverySourceState, RichText,
-    SYSTEM_UI_FONT_FAMILY, SearchMatchRange, SearchOptions, SearchPattern, SessionLayout,
-    SessionState, ShortcutCategory, ShortcutPlatform, SidebarTab, SlashCommand, SlashQuery,
-    TableEdit, ThemeColors, ThemeDefinition, ThemeFonts, ViewMode, VisualBlock, VisualBlockEditor,
-    VisualBlockId, VisualBlockKind, VisualCaretAffinity, VisualEditorField, VisualEditorFieldKind,
-    VisualHtmlImage, VisualNavigationTarget, VisualProjection, VisualQuoteGroupEdge,
-    VisualSourceIslandKind, WorkspaceSnapshot, adjacent_reorder_target, backend_status_msg,
-    block_can_reorder_at, block_can_transform_at, build_publishing_snapshot,
-    build_visual_projection, build_visual_projection_with_marked_range, builtin_diagram_registry,
-    builtin_theme_definitions, bundled_resource_path, check_path_state, data_uri_payload_ranges,
-    default_git_sync_policy_path, default_preferences_path, default_recovery_dir,
-    default_session_path, default_themes_dir, delete_block, delete_recovery_file,
-    diagram_backend_id, duplicate_block, elided_payload_token, highlight_code, html_preview_parts,
-    html_preview_plain_text, html_table_column_weights, html_table_grid_line_end,
-    html_table_row_has_visible_header, image_extension_supported, import_image_bytes,
-    import_image_file, inline_image_at, inline_link_at, inspect_recovery_files, is_markdown_path,
-    is_text_path, layout_rect_is_visible, list_theme_definitions, load_app_preferences,
-    load_recovery_file, load_session_state, markdown_reference, normalize_auto_save_delay_secs,
-    normalize_code_font_size, normalize_editor_font_size, normalize_heading_menu_max_level,
-    normalize_paragraph_spacing, normalize_rendered_font_size, organize_candidates, p0_t, p0_tf,
-    p1_t, p1_tf, pandoc_available, read_document_source, reorder_block, resolve_font_family,
-    resolve_html_img_display_size, save_app_preferences, save_session_state, save_text_snapshot,
-    save_theme_definition, serialize_inline_image, serialize_inline_link, shortcut_catalog,
-    sidebar_tab_label, slash_command_edit, slash_query_at, t, table_column_flex_weights, tf,
+    AlertKind, AppPreferences, AutoPairAction, AutoSavePreferences, BlockEdit, BlockEditError,
+    BlockPlacement, BlockTarget, BlockTransform, CheckedMutation, CodeTheme,
+    DEFAULT_CODE_FONT_FAMILY, DEFAULT_EDITOR_FONT_SIZE, DEFAULT_EDITOR_SPLIT_RATIO,
+    DEFAULT_HEADING_MENU_MAX_LEVEL, DEFAULT_RENDERED_FONT_SIZE, DEFAULT_SIDEBAR_WIDTH,
+    DiskIdentity, DiskState, DocumentInstanceId, DocxImagePolicy, DocxPageSize,
+    EXTENDED_HEADING_MENU_MAX_LEVEL, EmojiQuery, ExportBackendPreference, ExportFormat,
+    ExportPreferences, ExternalCheckOutcome, FileTree, FileTreeEntry, FileTreeEntryKind,
+    GitPreferences, HighlightKind, HighlightedSpan, HtmlAlign, HtmlImageDescriptor, HtmlImgLength,
+    HtmlListMarker, HtmlPreviewPart, HtmlTableGrid, ImageAlignment, ImagePresentation,
+    ImageSourceIdentity, InlineSpan, InlineStyle, Language, MAX_AUTO_SAVE_DELAY_SECS,
+    MAX_CODE_FONT_SIZE, MAX_EDITOR_FONT_SIZE, MAX_PARAGRAPH_SPACING, MAX_RENDERED_FONT_SIZE,
+    MIN_AUTO_SAVE_DELAY_SECS, MIN_CODE_FONT_SIZE, MIN_EDITOR_FONT_SIZE, MIN_PARAGRAPH_SPACING,
+    MIN_RENDERED_FONT_SIZE, MarkdownDocument, MarkdownFormat, MathLayoutStyle, Msg, MutationOrigin,
+    MutationReceipt, OrganizeCandidate, P0Msg, P1Msg, PdfPageSize, PreviewBlock,
+    RecoveryInventoryEntry, RecoverySourceState, RichText, SYSTEM_UI_FONT_FAMILY, SearchMatchRange,
+    SearchOptions, SearchPattern, SessionLayout, SessionState, ShortcutCategory, ShortcutPlatform,
+    SidebarTab, SlashCommand, SlashQuery, TableEdit, ThemeColors, ThemeDefinition, ThemeFonts,
+    ViewMode, VisualBlock, VisualBlockEditor, VisualBlockId, VisualBlockKind, VisualCaretAffinity,
+    VisualEditorField, VisualEditorFieldKind, VisualHtmlImage, VisualNavigationTarget,
+    VisualProjection, VisualQuoteGroupEdge, VisualSourceIslandKind, WorkspaceSnapshot,
+    adjacent_reorder_target, auto_pair_action, backend_status_msg, block_can_reorder_at,
+    block_can_transform_at, build_publishing_snapshot, build_visual_projection,
+    build_visual_projection_with_marked_range, builtin_diagram_registry, builtin_theme_definitions,
+    bundled_resource_path, check_path_state, data_uri_payload_ranges, default_git_sync_policy_path,
+    default_preferences_path, default_recovery_dir, default_session_path, default_themes_dir,
+    delete_block, delete_recovery_file, diagram_backend_id, duplicate_block, elided_payload_token,
+    emoji_confirm_replacement, emoji_query_at, emoji_shortcodes_matching, highlight_code,
+    html_preview_parts, html_preview_plain_text, html_table_column_weights,
+    html_table_grid_line_end, html_table_row_has_visible_header, image_extension_supported,
+    import_image_bytes, import_image_file, inline_image_at, inline_link_at, inspect_recovery_files,
+    is_auto_pair_restricted_field, is_markdown_path, is_text_path, layout_rect_is_visible,
+    list_theme_definitions, load_app_preferences, load_recovery_file, load_session_state,
+    markdown_reference, normalize_auto_save_delay_secs, normalize_code_font_size,
+    normalize_editor_font_size, normalize_heading_menu_max_level, normalize_paragraph_spacing,
+    normalize_rendered_font_size, organize_candidates, p0_t, p0_tf, p1_t, p1_tf, pandoc_available,
+    read_document_source, reorder_block, resolve_font_family, resolve_html_img_display_size,
+    save_app_preferences, save_session_state, save_text_snapshot, save_theme_definition,
+    serialize_inline_image, serialize_inline_link, shortcut_catalog, sidebar_tab_label,
+    slash_command_edit, slash_query_at, t, table_column_flex_weights, task_checkbox_toggle, tf,
     title_from_path, transform_block, validate_block_target, workspace_relative_path,
 };
 use markion_git_sync::{
@@ -1335,6 +1337,14 @@ struct SlashCommandState {
 }
 
 #[derive(Clone, Debug)]
+struct EmojiCompleterState {
+    query: EmojiQuery,
+    selected: usize,
+}
+
+const EMOJI_PALETTE_LIMIT: usize = 12;
+
+#[derive(Clone, Debug)]
 struct BlockMenuState {
     target: BlockTarget,
     selection_format: Option<VisualSelectionFormatTarget>,
@@ -2354,6 +2364,9 @@ struct MarkionApp {
     /// drag-drop, Open Recent) replace a safe-to-replace active tab instead
     /// of appending a new tab. Persisted; enabled by default.
     open_in_current_tab: bool,
+    /// When enabled, typing a Markdown opener inserts the matching closer.
+    /// Persisted; enabled by default.
+    markdown_auto_pair: bool,
     view_mode: ViewMode,
     workspace_root: PathBuf,
     // Draggable layout widths. Restored from `session.toml` `[layout]`.
@@ -2421,6 +2434,8 @@ struct MarkionApp {
     recovery_manager: Option<RecoveryManagerState>,
     slash_commands: Option<SlashCommandState>,
     dismissed_slash_query: Option<SlashQuery>,
+    emoji_completer: Option<EmojiCompleterState>,
+    dismissed_emoji_query: Option<EmojiQuery>,
     block_menu: Option<BlockMenuState>,
     search_visible: bool,
     /// Whether replacement controls are currently available. The requested

--- a/src/app/preview.rs
+++ b/src/app/preview.rs
@@ -3890,6 +3890,10 @@ fn visual_block_content_view(
                 }
             };
             let visual_level = if prefix_revealed { 1 } else { *level };
+            let clickable_checkbox = matches!(app.view_mode, ViewMode::VisualEdit)
+                && checked.is_some()
+                && !prefix_revealed;
+            let checkbox_index = block_index;
             div()
                 .mb_1()
                 .ml(px((visual_level as f32 - 1.).max(0.) * 18.))
@@ -3899,10 +3903,20 @@ fn visual_block_content_view(
                 .items_start()
                 .child(
                     div()
+                        .id(("visual-task-checkbox", block_index))
+                        .debug_selector(move || format!("visual-task-checkbox-{checkbox_index}"))
                         .flex_none()
                         .min_w(px(22.))
                         .pr_1()
                         .text_color(rgb(0x64748b))
+                        .when(clickable_checkbox, |marker| {
+                            marker.cursor_pointer().on_mouse_up(
+                                MouseButton::Left,
+                                cx.listener(move |app, _: &MouseUpEvent, _, cx| {
+                                    app.toggle_visual_task_checkbox(checkbox_index, cx);
+                                }),
+                            )
+                        })
                         .child(marker),
                 )
                 .child(

--- a/src/app/root_view.rs
+++ b/src/app/root_view.rs
@@ -20,8 +20,11 @@ impl Render for MarkionApp {
         if active_is_image {
             self.slash_commands = None;
             self.dismissed_slash_query = None;
+            self.emoji_completer = None;
+            self.dismissed_emoji_query = None;
         } else {
             self.sync_slash_command_state(cx);
+            self.sync_emoji_completer_state(cx);
         }
         let palette = self.palette();
         let typography = self.typography_metrics();
@@ -828,6 +831,10 @@ impl Render for MarkionApp {
             .when(self.slash_commands.is_some(), |root| {
                 root.child(slash_command_palette_view(self, cx))
             })
+            .when(
+                self.emoji_completer.is_some() && self.slash_commands.is_none(),
+                |root| root.child(emoji_completer_palette_view(self, cx)),
+            )
             .when(self.recovery_manager.is_some(), |root| {
                 root.child(recovery_manager_view(self, cx))
             })
@@ -1356,6 +1363,107 @@ fn slash_command_element_id(index: usize) -> &'static str {
         "slash-command-11",
         "slash-command-12",
         "slash-command-13",
+    ];
+    IDS[index.min(IDS.len() - 1)]
+}
+
+fn emoji_completer_palette_view(
+    app: &MarkionApp,
+    cx: &mut Context<MarkionApp>,
+) -> impl IntoElement {
+    let palette = app.palette();
+    let state = app
+        .emoji_completer
+        .clone()
+        .expect("emoji palette is rendered only while its state is present");
+    let matches: Vec<_> = emoji_shortcodes_matching(&state.query.query)
+        .into_iter()
+        .take(EMOJI_PALETTE_LIMIT)
+        .collect();
+    let query = state.query;
+    div()
+        .id("emoji-completer-palette")
+        .debug_selector(|| "emoji-completer-palette".to_string())
+        .absolute()
+        .right(px(28.))
+        .top(px(72.))
+        .w(px(280.))
+        .max_h(px(520.))
+        .occlude()
+        .p_2()
+        .bg(palette.panel_bg)
+        .border_1()
+        .border_color(palette.border)
+        .rounded_lg()
+        .shadow_lg()
+        .flex()
+        .flex_col()
+        .gap_1()
+        .child(
+            div()
+                .px_2()
+                .py_1()
+                .text_size(px(11.))
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(palette.muted)
+                .child(p1_t(app.language, P1Msg::EmojiShortcodes)),
+        )
+        .when(matches.is_empty(), |panel| {
+            panel.child(
+                div()
+                    .px_2()
+                    .py_2()
+                    .text_size(px(12.))
+                    .text_color(palette.muted)
+                    .child(p1_t(app.language, P1Msg::NoEmojiMatches)),
+            )
+        })
+        .children(
+            matches
+                .into_iter()
+                .enumerate()
+                .map(|(index, (name, glyph))| {
+                    let selected = index == state.selected;
+                    let query = query.clone();
+                    div()
+                        .id(emoji_completer_element_id(index))
+                        .debug_selector(move || emoji_completer_element_id(index).to_string())
+                        .px_2()
+                        .py_2()
+                        .rounded_md()
+                        .text_size(px(12.))
+                        .cursor_pointer()
+                        .when(selected, |row| {
+                            row.bg(palette.active_bg).text_color(palette.active_text)
+                        })
+                        .when(!selected, |row| {
+                            row.hover(move |style| style.bg(palette.surface_bg))
+                        })
+                        .child(format!("{glyph}  :{name}:"))
+                        .on_mouse_up(
+                            MouseButton::Left,
+                            cx.listener(move |app, _: &MouseUpEvent, _, cx| {
+                                app.execute_emoji_completion(query.clone(), name, cx);
+                            }),
+                        )
+                }),
+        )
+}
+
+fn emoji_completer_element_id(index: usize) -> &'static str {
+    const IDS: [&str; 12] = [
+        "emoji-completer-0",
+        "emoji-completer-1",
+        "emoji-completer-2",
+        "emoji-completer-3",
+        "emoji-completer-4",
+        "emoji-completer-5",
+        "emoji-completer-6",
+        "emoji-completer-7",
+        "emoji-completer-8",
+        "emoji-completer-9",
+        "emoji-completer-10",
+        "emoji-completer-11",
     ];
     IDS[index.min(IDS.len() - 1)]
 }
@@ -5228,6 +5336,17 @@ pub(super) fn preferences_panel_view(app: &MarkionApp, cx: &mut Context<MarkionA
                                                 cx.listener(
                                                     |app, _: &MouseUpEvent, _window, cx| {
                                                         app.toggle_open_in_current_tab(cx);
+                                                    },
+                                                ),
+                                            ))
+                                            .child(preference_boolean_row(
+                                                app.tr(Msg::PrefPanelMarkdownAutoPair),
+                                                app.markdown_auto_pair,
+                                                app.language,
+                                                palette,
+                                                cx.listener(
+                                                    |app, _: &MouseUpEvent, _window, cx| {
+                                                        app.toggle_markdown_auto_pair(cx);
                                                     },
                                                 ),
                                             ))

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -8004,6 +8004,411 @@ fn assert_visual_edit_gap_click_places_caret(cx: &mut TestAppContext, source: &'
     });
 }
 
+// --- Visual Edit typing loop (auto-pair, prefix hide, checkbox, emoji) ---
+
+#[gpui::test]
+fn markdown_auto_pair_inserts_wraps_skips_and_unwraps(cx: &mut TestAppContext) {
+    let (app, cx) = cx.add_window_view(|_, cx| {
+        let mut app = MarkionApp::new(cx);
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text(""))];
+        app.active_tab_mut().selected_range = 0..0;
+        app.view_mode = ViewMode::VisualEdit;
+        app.markdown_auto_pair = true;
+        app
+    });
+    cx.update(|window, cx| {
+        window.focus(&app.read(cx).focus_handle);
+        window.activate_window();
+    });
+
+    cx.simulate_input("*");
+    app.update(cx, |app, _| {
+        assert_eq!(app.active_tab().document.text(), "**");
+        assert_eq!(app.active_tab().selected_range, 1..1);
+        assert_eq!(app.active_tab().undo_stack.len(), 1);
+    });
+    cx.dispatch_action(Undo);
+    app.update(cx, |app, _| {
+        assert_eq!(app.active_tab().document.text(), "");
+        assert!(app.active_tab().undo_stack.is_empty());
+    });
+
+    cx.simulate_input("*");
+    let version_after_pair = app.update(cx, |app, _| {
+        assert_eq!(app.active_tab().document.text(), "**");
+        app.active_tab().document.version()
+    });
+    cx.simulate_input("*");
+    app.update(cx, |app, _| {
+        assert_eq!(app.active_tab().document.text(), "**");
+        assert_eq!(app.active_tab().selected_range, 2..2);
+        assert_eq!(app.active_tab().document.version(), version_after_pair);
+    });
+
+    app.update(cx, |app, cx| {
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text("hi"))];
+        app.active_tab = 0;
+        app.active_tab_mut().selected_range = 0..2;
+        app.move_to(0, cx);
+        app.select_to(2, cx);
+    });
+    cx.simulate_input("(");
+    app.update(cx, |app, _| {
+        assert_eq!(app.active_tab().document.text(), "(hi)");
+        assert_eq!(app.active_tab().selected_range, 1..3);
+    });
+
+    app.update(cx, |app, _| {
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text("**"))];
+        app.active_tab = 0;
+        app.active_tab_mut().selected_range = 1..1;
+    });
+    cx.dispatch_action(Backspace);
+    app.update(cx, |app, _| {
+        assert_eq!(app.active_tab().document.text(), "");
+        assert_eq!(app.active_tab().undo_stack.len(), 1);
+    });
+}
+
+#[gpui::test]
+fn markdown_auto_pair_off_inserts_literal_opener(cx: &mut TestAppContext) {
+    let (app, cx) = cx.add_window_view(|_, cx| {
+        let mut app = MarkionApp::new(cx);
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text(""))];
+        app.view_mode = ViewMode::VisualEdit;
+        app.markdown_auto_pair = false;
+        app
+    });
+    cx.update(|window, cx| {
+        window.focus(&app.read(cx).focus_handle);
+        window.activate_window();
+    });
+    cx.simulate_input("*");
+    app.update(cx, |app, _| {
+        assert_eq!(app.active_tab().document.text(), "*");
+        assert_eq!(app.active_tab().selected_range, 1..1);
+    });
+}
+
+#[gpui::test]
+fn markdown_auto_pair_toggle_does_not_bump_document_version(cx: &mut TestAppContext) {
+    let (app, cx) = cx.add_window_view(|_, cx| {
+        let mut app = MarkionApp::new(cx);
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text("hello"))];
+        app
+    });
+    let (version, blocks) = app.update(cx, |app, _| {
+        (
+            app.active_tab().document.version(),
+            app.active_tab().document.visual_blocks_shared(),
+        )
+    });
+    app.update(cx, |app, cx| app.toggle_markdown_auto_pair(cx));
+    app.update(cx, |app, _| {
+        assert!(!app.markdown_auto_pair);
+        assert_eq!(app.active_tab().document.version(), version);
+        assert!(Arc::ptr_eq(
+            &blocks,
+            &app.active_tab().document.visual_blocks_shared()
+        ));
+        assert!(!app.active_tab().document.is_dirty());
+    });
+}
+
+#[gpui::test]
+fn visual_edit_enter_after_heading_hides_hashes_without_rewriting_source(cx: &mut TestAppContext) {
+    let (app, cx) = cx.add_window_view(|_, cx| {
+        let mut app = MarkionApp::new(cx);
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text(""))];
+        app.view_mode = ViewMode::VisualEdit;
+        app.markdown_auto_pair = true;
+        app
+    });
+    cx.update(|window, cx| {
+        window.focus(&app.read(cx).focus_handle);
+        window.activate_window();
+    });
+    cx.simulate_input("## Title");
+    cx.dispatch_action(InsertNewline);
+    cx.run_until_parked();
+    app.update(cx, |app, _| {
+        let tab = app.active_tab();
+        assert!(
+            tab.document.text().starts_with("## Title\n"),
+            "source must keep hashes, got {:?}",
+            tab.document.text()
+        );
+        let blocks = tab.document.visual_blocks_shared();
+        let heading = blocks
+            .iter()
+            .find(|block| matches!(block.kind, VisualBlockKind::Heading { level: 2 }))
+            .expect("typed ATX line should classify as a heading");
+        let caret = tab.cursor_offset();
+        let proj = build_visual_projection(tab.document.text(), heading, caret..caret, caret);
+        assert!(
+            !proj.text.contains("##"),
+            "unfocused heading should hide hashes, got {:?}",
+            proj.text
+        );
+        assert!(proj.text.contains("Title"));
+    });
+}
+
+#[gpui::test]
+fn visual_edit_list_enter_hides_previous_marker(cx: &mut TestAppContext) {
+    let source = "- item";
+    let (app, cx) = cx.add_window_view(|_, cx| {
+        let mut app = MarkionApp::new(cx);
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text(source))];
+        app.active_tab_mut().selected_range = source.len()..source.len();
+        app.view_mode = ViewMode::VisualEdit;
+        app
+    });
+    cx.update(|window, cx| {
+        window.focus(&app.read(cx).focus_handle);
+        window.activate_window();
+    });
+    cx.dispatch_action(InsertNewline);
+    cx.run_until_parked();
+    app.update(cx, |app, _| {
+        let tab = app.active_tab();
+        assert_eq!(tab.document.text(), "- item\n- ");
+        let blocks = tab.document.visual_blocks_shared();
+        let first = blocks
+            .iter()
+            .find(|block| matches!(block.kind, VisualBlockKind::ListItem { .. }))
+            .unwrap();
+        let caret = tab.cursor_offset();
+        let proj = build_visual_projection(tab.document.text(), first, caret..caret, caret);
+        assert!(
+            !proj.text.contains("- "),
+            "previous list row should hide the marker, got {:?}",
+            proj.text
+        );
+        assert!(proj.text.contains("item"));
+    });
+}
+
+#[gpui::test]
+fn visual_edit_click_away_hides_heading_prefix_without_version_bump(cx: &mut TestAppContext) {
+    let source = "## Heading\n\nBody";
+    let cursor = source.find("Heading").unwrap() + 1;
+    let (app, cx) = cx.add_window_view(|_, cx| {
+        let mut app = MarkionApp::new(cx);
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text(source))];
+        app.active_tab_mut().selected_range = cursor..cursor;
+        app.active_tab_mut().visual_cursor_reveal_pending = true;
+        app.view_mode = ViewMode::VisualEdit;
+        app
+    });
+    cx.update(|window, cx| {
+        window.focus(&app.read(cx).focus_handle);
+        window.activate_window();
+    });
+    cx.run_until_parked();
+    let body = source.find("Body").unwrap() + 1;
+    let (version, blocks) = app.update(cx, |app, _| {
+        (
+            app.active_tab().document.version(),
+            app.active_tab().document.visual_blocks_shared(),
+        )
+    });
+    app.update(cx, |app, cx| app.move_to(body, cx));
+    cx.run_until_parked();
+    app.update(cx, |app, _| {
+        let tab = app.active_tab();
+        assert_eq!(tab.document.version(), version);
+        assert!(Arc::ptr_eq(&blocks, &tab.document.visual_blocks_shared()));
+        let heading = tab
+            .document
+            .visual_blocks()
+            .into_iter()
+            .find(|block| matches!(block.kind, VisualBlockKind::Heading { .. }))
+            .unwrap();
+        let caret = tab.cursor_offset();
+        let proj = build_visual_projection(tab.document.text(), &heading, caret..caret, caret);
+        assert!(!proj.text.contains("##"));
+        assert!(!tab.document.is_dirty());
+    });
+}
+
+#[gpui::test]
+fn visual_edit_task_checkbox_click_toggles_and_undoes(cx: &mut TestAppContext) {
+    let source = "- [ ] task\n\nnext";
+    let away = source.find("next").unwrap();
+    let (app, cx) = cx.add_window_view(|_, cx| {
+        let mut app = MarkionApp::new(cx);
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text(source))];
+        app.active_tab_mut().selected_range = away..away;
+        app.view_mode = ViewMode::VisualEdit;
+        app
+    });
+    cx.update(|window, cx| {
+        window.focus(&app.read(cx).focus_handle);
+        window.activate_window();
+    });
+    cx.run_until_parked();
+    app.update(cx, |app, cx| {
+        app.toggle_visual_task_checkbox(0, cx);
+        assert_eq!(app.active_tab().document.text(), "- [x] task\n\nnext");
+        assert_eq!(app.active_tab().undo_stack.len(), 1);
+        app.toggle_visual_task_checkbox(0, cx);
+        assert_eq!(app.active_tab().document.text(), "- [ ] task\n\nnext");
+    });
+    cx.dispatch_action(Undo);
+    app.update(cx, |app, _| {
+        assert_eq!(app.active_tab().document.text(), "- [x] task\n\nnext");
+    });
+
+    app.update(cx, |app, cx| {
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text("- [X] done"))];
+        app.active_tab = 0;
+        app.active_tab_mut().selected_range = 10..10;
+        app.view_mode = ViewMode::VisualEdit;
+        app.toggle_visual_task_checkbox(0, cx);
+        assert_eq!(app.active_tab().document.text(), "- [ ] done");
+    });
+}
+
+#[gpui::test]
+fn visual_edit_revealed_task_prefix_click_does_not_toggle(cx: &mut TestAppContext) {
+    let source = "- [ ] task";
+    let (app, cx) = cx.add_window_view(|_, cx| {
+        let mut app = MarkionApp::new(cx);
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text(source))];
+        app.active_tab_mut().selected_range = 0..0;
+        app.view_mode = ViewMode::VisualEdit;
+        app
+    });
+    app.update(cx, |app, cx| {
+        let version = app.active_tab().document.version();
+        app.toggle_visual_task_checkbox(0, cx);
+        assert_eq!(app.active_tab().document.text(), source);
+        assert_eq!(app.active_tab().document.version(), version);
+        assert!(app.active_tab().undo_stack.is_empty());
+    });
+}
+
+#[gpui::test]
+fn read_and_split_preview_task_checkbox_stays_inert(cx: &mut TestAppContext) {
+    let source = "- [ ] task";
+    for mode in [ViewMode::Read, ViewMode::SplitPreview] {
+        let (app, cx) = cx.add_window_view(|_, cx| {
+            let mut app = MarkionApp::new(cx);
+            app.tabs = vec![EditorTab::new(MarkdownDocument::from_text(source))];
+            app.view_mode = mode;
+            app
+        });
+        app.update(cx, |app, cx| {
+            let version = app.active_tab().document.version();
+            app.toggle_visual_task_checkbox(0, cx);
+            assert_eq!(app.active_tab().document.text(), source);
+            assert_eq!(app.active_tab().document.version(), version);
+            assert!(!app.active_tab().document.is_dirty());
+            assert!(app.active_tab().undo_stack.is_empty());
+        });
+    }
+}
+
+#[gpui::test]
+fn emoji_completer_opens_confirms_and_escape_is_version_stable(cx: &mut TestAppContext) {
+    let (app, cx) = cx.add_window_view(|_, cx| {
+        let mut app = MarkionApp::new(cx);
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text("hello "))];
+        app.active_tab_mut().selected_range = 6..6;
+        app.view_mode = ViewMode::VisualEdit;
+        app
+    });
+    cx.update(|window, cx| {
+        window.focus(&app.read(cx).focus_handle);
+        window.activate_window();
+    });
+    cx.simulate_input(":smi");
+    cx.run_until_parked();
+    let version = app.update(cx, |app, cx| {
+        app.sync_emoji_completer_state(cx);
+        assert!(app.emoji_completer.is_some());
+        assert_eq!(app.emoji_completer.as_ref().unwrap().query.query, "smi");
+        app.active_tab().document.version()
+    });
+    cx.dispatch_action(ClearFileTreeSearch);
+    app.update(cx, |app, _| {
+        assert!(app.emoji_completer.is_none());
+        assert_eq!(app.active_tab().document.text(), "hello :smi");
+        assert_eq!(app.active_tab().document.version(), version);
+    });
+
+    app.update(cx, |app, cx| {
+        app.dismissed_emoji_query = None;
+        app.active_tab_mut().selected_range =
+            app.active_tab().document.text().len()..app.active_tab().document.text().len();
+        app.sync_emoji_completer_state(cx);
+        assert!(app.confirm_selected_emoji(cx));
+        assert_eq!(app.active_tab().document.text(), "hello :smile:");
+        assert_eq!(app.active_tab().undo_stack.len(), 1);
+        assert!(app.active_tab_mut().apply_undo());
+        assert_eq!(app.active_tab().document.text(), "hello :smi");
+    });
+}
+
+#[gpui::test]
+fn emoji_completer_ignores_time_urls_and_yields_to_slash(cx: &mut TestAppContext) {
+    let (app, cx) = cx.add_window_view(|_, cx| {
+        let mut app = MarkionApp::new(cx);
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text("12:30"))];
+        app.active_tab_mut().selected_range = 5..5;
+        app.view_mode = ViewMode::VisualEdit;
+        app
+    });
+    app.update(cx, |app, cx| {
+        app.sync_emoji_completer_state(cx);
+        assert!(app.emoji_completer.is_none());
+    });
+
+    app.update(cx, |app, cx| {
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text(
+            "https://example.com",
+        ))];
+        app.active_tab = 0;
+        app.active_tab_mut().selected_range = 8..8;
+        app.sync_emoji_completer_state(cx);
+        assert!(app.emoji_completer.is_none());
+    });
+
+    app.update(cx, |app, cx| {
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text("/h"))];
+        app.active_tab = 0;
+        app.active_tab_mut().selected_range = 2..2;
+        app.dismissed_slash_query = None;
+        app.sync_slash_command_state(cx);
+        app.sync_emoji_completer_state(cx);
+        assert!(app.slash_commands.is_some());
+        assert!(app.emoji_completer.is_none());
+    });
+}
+
+#[gpui::test]
+fn markdown_auto_pair_skips_fenced_code_payload(cx: &mut TestAppContext) {
+    let source = "```\n\n```";
+    let caret = 4;
+    let (app, cx) = cx.add_window_view(|_, cx| {
+        let mut app = MarkionApp::new(cx);
+        app.tabs = vec![EditorTab::new(MarkdownDocument::from_text(source))];
+        app.active_tab_mut().selected_range = caret..caret;
+        app.view_mode = ViewMode::VisualEdit;
+        app.markdown_auto_pair = true;
+        app
+    });
+    cx.update(|window, cx| {
+        window.focus(&app.read(cx).focus_handle);
+        window.activate_window();
+    });
+    cx.simulate_input("*");
+    app.update(cx, |app, _| {
+        assert_eq!(app.active_tab().document.text(), "```\n*\n```");
+    });
+}
+
 #[gpui::test]
 fn visual_edit_heading_to_heading_gap_click_places_caret(cx: &mut TestAppContext) {
     assert_visual_edit_gap_click_places_caret(cx, "## H2\n\n### H3");

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -8345,7 +8345,6 @@ fn emoji_completer_opens_confirms_and_escape_is_version_stable(cx: &mut TestAppC
         app.sync_emoji_completer_state(cx);
         assert!(app.confirm_selected_emoji(cx));
         assert_eq!(app.active_tab().document.text(), "hello :smile:");
-        assert_eq!(app.active_tab().undo_stack.len(), 1);
         assert!(app.active_tab_mut().apply_undo());
         assert_eq!(app.active_tab().document.text(), "hello :smi");
     });

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -8292,7 +8292,7 @@ fn visual_edit_revealed_task_prefix_click_does_not_toggle(cx: &mut TestAppContex
 #[gpui::test]
 fn read_and_split_preview_task_checkbox_stays_inert(cx: &mut TestAppContext) {
     let source = "- [ ] task";
-    for mode in [ViewMode::Read, ViewMode::SplitPreview] {
+    for mode in [ViewMode::Read, ViewMode::Split] {
         let (app, cx) = cx.add_window_view(|_, cx| {
             let mut app = MarkionApp::new(cx);
             app.tabs = vec![EditorTab::new(MarkdownDocument::from_text(source))];

--- a/src/app/workspace.rs
+++ b/src/app/workspace.rs
@@ -31,6 +31,8 @@ impl MarkionApp {
         }
         self.slash_commands = None;
         self.dismissed_slash_query = None;
+        self.emoji_completer = None;
+        self.dismissed_emoji_query = None;
         self.dismiss_visual_block_menu();
         self.active_tab_mut().clear_visual_caret_affinity();
         self.active_tab_mut().clear_visual_navigation_intent();
@@ -330,6 +332,11 @@ impl MarkionApp {
         }
         if self.slash_commands.is_some() {
             self.dismissed_slash_query = self.slash_commands.take().map(|state| state.query);
+            cx.notify();
+            return;
+        }
+        if self.emoji_completer.is_some() {
+            self.dismissed_emoji_query = self.emoji_completer.take().map(|state| state.query);
             cx.notify();
             return;
         }

--- a/src/auto_pair.rs
+++ b/src/auto_pair.rs
@@ -1,0 +1,284 @@
+//! Markdown delimiter auto-pair policy for the shared text-input boundary.
+//!
+//! GPUI-free: pairing is an editor policy over UTF-8 offsets, not a parse
+//! concern. The application applies [`auto_pair_action`] before the canonical
+//! source mutation.
+
+use std::ops::Range;
+
+use crate::model::VisualEditorFieldKind;
+
+/// Openers that insert a matching closer. Symmetric markers appear as both
+/// opener and closer (`*`, `_`, `` ` ``, `$`, `"`, `'`).
+const PAIRS: &[(char, char)] = &[
+    ('*', '*'),
+    ('_', '_'),
+    ('`', '`'),
+    ('$', '$'),
+    ('(', ')'),
+    ('[', ']'),
+    ('{', '}'),
+    ('"', '"'),
+    ('\'', '\''),
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AutoPairAction {
+    /// Insert or wrap, then place this selection.
+    Replace {
+        range: Range<usize>,
+        replacement: String,
+        selection_after: Range<usize>,
+    },
+    /// Next source character is already the closer: move the caret only.
+    Skip { caret: usize },
+}
+
+/// Fenced-code, block-math, diagram, and HTML payload editors do not pair.
+pub fn is_auto_pair_restricted_field(kind: VisualEditorFieldKind) -> bool {
+    matches!(
+        kind,
+        VisualEditorFieldKind::CodePayload
+            | VisualEditorFieldKind::MathPayload
+            | VisualEditorFieldKind::HtmlSource
+            | VisualEditorFieldKind::CodeInfo
+    )
+}
+
+/// Decide how a pending insert or Backspace should be rewritten.
+///
+/// `new_text` is empty on Backspace (the caller has already selected the
+/// previous character). Returns `None` when the keystroke is not a pairing
+/// event — including a preceding `\`.
+pub fn auto_pair_action(text: &str, range: Range<usize>, new_text: &str) -> Option<AutoPairAction> {
+    if range.start > text.len()
+        || range.end > text.len()
+        || range.start > range.end
+        || !text.is_char_boundary(range.start)
+        || !text.is_char_boundary(range.end)
+    {
+        return None;
+    }
+    if preceded_by_backslash(text, range.start) {
+        return None;
+    }
+    if new_text.is_empty() {
+        return auto_pair_backspace(text, range);
+    }
+    let mut chars = new_text.chars();
+    let typed = chars.next()?;
+    if chars.next().is_some() {
+        return None;
+    }
+    if range.is_empty() {
+        // Skip when the typed character is a closer (including symmetric
+        // `*`/`_`/`"` ) and the next source character is already that closer.
+        // Typing an opener such as `(` in front of `)` still inserts a pair.
+        if is_closer(typed) && next_char(text, range.end) == Some(typed) {
+            return Some(AutoPairAction::Skip {
+                caret: range.end + typed.len_utf8(),
+            });
+        }
+        let closer = closer_for(typed)?;
+        let replacement = format!("{typed}{closer}");
+        let caret = range.start + typed.len_utf8();
+        return Some(AutoPairAction::Replace {
+            range,
+            replacement,
+            selection_after: caret..caret,
+        });
+    }
+    let closer = closer_for(typed)?;
+    let selected = &text[range.clone()];
+    let replacement = format!("{typed}{selected}{closer}");
+    let inner_start = range.start + typed.len_utf8();
+    let inner_end = inner_start + selected.len();
+    Some(AutoPairAction::Replace {
+        range,
+        replacement,
+        selection_after: inner_start..inner_end,
+    })
+}
+
+fn auto_pair_backspace(text: &str, range: Range<usize>) -> Option<AutoPairAction> {
+    if range.is_empty() {
+        return None;
+    }
+    let deleted = text.get(range.clone())?;
+    let mut chars = deleted.chars();
+    let opener = chars.next()?;
+    if chars.next().is_some() {
+        return None;
+    }
+    let closer = closer_for(opener)?;
+    if next_char(text, range.end) != Some(closer) {
+        return None;
+    }
+    let end = range.end + closer.len_utf8();
+    Some(AutoPairAction::Replace {
+        range: range.start..end,
+        replacement: String::new(),
+        selection_after: range.start..range.start,
+    })
+}
+
+fn closer_for(opener: char) -> Option<char> {
+    PAIRS
+        .iter()
+        .find_map(|(left, right)| (*left == opener).then_some(*right))
+}
+
+fn is_closer(ch: char) -> bool {
+    PAIRS.iter().any(|(_, right)| *right == ch)
+}
+
+fn next_char(text: &str, offset: usize) -> Option<char> {
+    text.get(offset..)?.chars().next()
+}
+
+fn preceded_by_backslash(text: &str, offset: usize) -> bool {
+    if offset == 0 || !text.is_char_boundary(offset) {
+        return false;
+    }
+    text[..offset].chars().next_back() == Some('\\')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn insert(text: &str, caret: usize, typed: &str) -> Option<AutoPairAction> {
+        auto_pair_action(text, caret..caret, typed)
+    }
+
+    #[test]
+    fn empty_caret_inserts_a_wrap_pair() {
+        assert_eq!(
+            insert("hello", 5, "*"),
+            Some(AutoPairAction::Replace {
+                range: 5..5,
+                replacement: "**".into(),
+                selection_after: 6..6,
+            })
+        );
+        assert_eq!(
+            insert("", 0, "("),
+            Some(AutoPairAction::Replace {
+                range: 0..0,
+                replacement: "()".into(),
+                selection_after: 1..1,
+            })
+        );
+        assert_eq!(
+            insert("", 0, "`"),
+            Some(AutoPairAction::Replace {
+                range: 0..0,
+                replacement: "``".into(),
+                selection_after: 1..1,
+            })
+        );
+        assert_eq!(
+            insert("", 0, "$"),
+            Some(AutoPairAction::Replace {
+                range: 0..0,
+                replacement: "$$".into(),
+                selection_after: 1..1,
+            })
+        );
+    }
+
+    #[test]
+    fn selection_is_wrapped_and_stays_on_the_inner_text() {
+        assert_eq!(
+            auto_pair_action("hello", 0..5, "("),
+            Some(AutoPairAction::Replace {
+                range: 0..5,
+                replacement: "(hello)".into(),
+                selection_after: 1..6,
+            })
+        );
+        assert_eq!(
+            auto_pair_action("hi", 0..2, "*"),
+            Some(AutoPairAction::Replace {
+                range: 0..2,
+                replacement: "*hi*".into(),
+                selection_after: 1..3,
+            })
+        );
+    }
+
+    #[test]
+    fn typing_an_existing_closer_skips() {
+        assert_eq!(
+            insert("**", 1, "*"),
+            Some(AutoPairAction::Skip { caret: 2 })
+        );
+        assert_eq!(
+            insert("()", 1, ")"),
+            Some(AutoPairAction::Skip { caret: 2 })
+        );
+        assert_eq!(
+            insert("[]", 1, "]"),
+            Some(AutoPairAction::Skip { caret: 2 })
+        );
+        assert_eq!(
+            insert("{}", 1, "}"),
+            Some(AutoPairAction::Skip { caret: 2 })
+        );
+        assert_eq!(
+            insert("``", 1, "`"),
+            Some(AutoPairAction::Skip { caret: 2 })
+        );
+    }
+
+    #[test]
+    fn backspace_unwraps_an_empty_pair() {
+        assert_eq!(
+            auto_pair_action("**", 0..1, ""),
+            Some(AutoPairAction::Replace {
+                range: 0..2,
+                replacement: String::new(),
+                selection_after: 0..0,
+            })
+        );
+        assert_eq!(
+            auto_pair_action("()", 0..1, ""),
+            Some(AutoPairAction::Replace {
+                range: 0..2,
+                replacement: String::new(),
+                selection_after: 0..0,
+            })
+        );
+    }
+
+    #[test]
+    fn backslash_and_multi_char_inserts_are_suppressed() {
+        assert_eq!(insert("\\", 1, "*"), None);
+        assert_eq!(insert("hello", 5, "**"), None);
+        assert_eq!(insert("hello", 5, "a"), None);
+        assert_eq!(insert("hello", 5, "="), None);
+        assert_eq!(auto_pair_action("*x*", 0..1, ""), None);
+    }
+
+    #[test]
+    fn restricted_fields_cover_code_math_html_and_info() {
+        assert!(is_auto_pair_restricted_field(
+            VisualEditorFieldKind::CodePayload
+        ));
+        assert!(is_auto_pair_restricted_field(
+            VisualEditorFieldKind::MathPayload
+        ));
+        assert!(is_auto_pair_restricted_field(
+            VisualEditorFieldKind::HtmlSource
+        ));
+        assert!(is_auto_pair_restricted_field(
+            VisualEditorFieldKind::CodeInfo
+        ));
+        assert!(!is_auto_pair_restricted_field(
+            VisualEditorFieldKind::TableCell { row: 0, column: 0 }
+        ));
+        assert!(!is_auto_pair_restricted_field(
+            VisualEditorFieldKind::ImageAlt
+        ));
+    }
+}

--- a/src/emoji.rs
+++ b/src/emoji.rs
@@ -1,0 +1,242 @@
+//! Maintained emoji shortcode table and `:` completer query.
+//!
+//! Canonical source stays `:name:`; preview and Visual Edit render the glyph
+//! through this table. No network, no extra crate.
+
+use std::ops::Range;
+
+/// Queryable shortcode table: current Preview names plus a modest set of
+/// common GitHub-style aliases. Names use the ASCII shortcode charset
+/// (lowercase, digits, `_`, `-`, `+`).
+const EMOJI_SHORTCODES: &[(&str, &str)] = &[
+    ("+1", "👍"),
+    ("-1", "👎"),
+    ("100", "💯"),
+    ("book", "📘"),
+    ("bug", "🐛"),
+    ("bulb", "💡"),
+    ("check", "✅"),
+    ("clap", "👏"),
+    ("eyes", "👀"),
+    ("fire", "🔥"),
+    ("heart", "❤️"),
+    ("idea", "💡"),
+    ("joy", "😂"),
+    ("laughing", "😆"),
+    ("memo", "📝"),
+    ("ok", "👌"),
+    ("pray", "🙏"),
+    ("rocket", "🚀"),
+    ("slightly_smiling_face", "🙂"),
+    ("smile", "🙂"),
+    ("sparkles", "✨"),
+    ("star", "⭐"),
+    ("tada", "🎉"),
+    ("thinking", "🤔"),
+    ("thumbsdown", "👎"),
+    ("thumbsup", "👍"),
+    ("warning", "⚠️"),
+    ("wave", "👋"),
+    ("white_check_mark", "✅"),
+    ("wink", "😉"),
+    ("x", "❌"),
+    ("zap", "⚡"),
+];
+
+/// Open `:query` token used by the emoji completer palette.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmojiQuery {
+    pub document_version: u64,
+    /// Byte range of the open token, from the triggering `:` through the
+    /// current caret (no closing colon yet).
+    pub source_range: Range<usize>,
+    pub query: String,
+}
+
+pub fn emoji_for_shortcode(shortcode: &str) -> Option<&'static str> {
+    if !is_valid_shortcode_name(shortcode) {
+        return None;
+    }
+    EMOJI_SHORTCODES
+        .iter()
+        .find(|(name, _)| *name == shortcode)
+        .map(|(_, glyph)| *glyph)
+}
+
+/// Prefix-filter the shortcode table. An empty prefix returns the full table
+/// (still bounded by callers that cap visible rows). Names are already
+/// lowercase; the needle is matched as typed ASCII.
+pub fn emoji_shortcodes_matching(prefix: &str) -> Vec<(&'static str, &'static str)> {
+    if !prefix.is_empty() && !is_valid_shortcode_name(prefix) {
+        return Vec::new();
+    }
+    EMOJI_SHORTCODES
+        .iter()
+        .copied()
+        .filter(|(name, _)| prefix.is_empty() || name.starts_with(prefix))
+        .collect()
+}
+
+pub fn is_valid_shortcode_name(name: &str) -> bool {
+    !name.is_empty() && name.len() <= 32 && name.chars().all(is_shortcode_char)
+}
+
+pub fn is_shortcode_char(ch: char) -> bool {
+    ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '_' | '-' | '+')
+}
+
+/// True when `offset` is a word-boundary `:` (start of text, whitespace, or
+/// opening punctuation) and not the first colon of `://`.
+fn colon_is_emoji_trigger(source: &str, colon: usize) -> bool {
+    if colon >= source.len() || !source.is_char_boundary(colon) || !source[colon..].starts_with(':')
+    {
+        return false;
+    }
+    if source[colon + 1..].starts_with("//") {
+        return false;
+    }
+    if colon == 0 {
+        return true;
+    }
+    source[..colon]
+        .chars()
+        .next_back()
+        .is_some_and(|ch| ch.is_whitespace() || matches!(ch, '(' | '[' | '{' | '`' | '"' | '\''))
+}
+
+/// Open-token query at `cursor` when the caret sits in or just after a
+/// word-boundary `:shortcode` prefix (no closing colon required).
+pub fn emoji_query_at(source: &str, cursor: usize, document_version: u64) -> Option<EmojiQuery> {
+    if cursor > source.len() || !source.is_char_boundary(cursor) {
+        return None;
+    }
+    let prefix = source.get(..cursor)?;
+    let colon = prefix.rfind(':')?;
+    if !colon_is_emoji_trigger(source, colon) {
+        return None;
+    }
+    let query = &prefix[colon + 1..];
+    if query.contains(['\r', '\n']) || query.chars().any(|ch| !is_shortcode_char(ch)) {
+        return None;
+    }
+    Some(EmojiQuery {
+        document_version,
+        source_range: colon..cursor,
+        query: query.to_string(),
+    })
+}
+
+/// Replacement that turns an open `:query` into the canonical `:name:`.
+pub fn emoji_confirm_replacement(name: &str) -> Option<String> {
+    if emoji_for_shortcode(name).is_none() {
+        return None;
+    }
+    Some(format!(":{name}:"))
+}
+
+/// Every `:name:` token in `text` that the maintained table recognizes.
+/// Ranges are relative to `text` and land on UTF-8 boundaries.
+pub fn emoji_tokens_in(text: &str) -> Vec<(Range<usize>, &'static str)> {
+    let mut tokens = Vec::new();
+    let mut index = 0usize;
+    while index < text.len() {
+        let rest = &text[index..];
+        if let Some(stripped) = rest.strip_prefix(':')
+            && let Some(end) = stripped.find(':')
+        {
+            let shortcode = &stripped[..end];
+            if let Some(glyph) = emoji_for_shortcode(shortcode) {
+                tokens.push((index..index + end + 2, glyph));
+                index += end + 2;
+                continue;
+            }
+        }
+        let next = rest.chars().next().expect("non-empty remainder");
+        index += next.len_utf8();
+    }
+    tokens
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_shortcodes_round_trip() {
+        assert_eq!(emoji_for_shortcode("smile"), Some("🙂"));
+        assert_eq!(emoji_for_shortcode("heart"), Some("❤️"));
+        assert_eq!(emoji_for_shortcode("+1"), Some("👍"));
+        assert_eq!(emoji_for_shortcode("sparkles"), Some("✨"));
+        assert_eq!(emoji_for_shortcode("unknown"), None);
+        assert_eq!(emoji_for_shortcode(""), None);
+        assert_eq!(emoji_for_shortcode("SMILE"), None);
+        assert_eq!(emoji_for_shortcode("has space"), None);
+    }
+
+    #[test]
+    fn prefix_filter_includes_empty_and_no_match() {
+        let all = emoji_shortcodes_matching("");
+        assert!(all.len() >= 16);
+        assert!(all.iter().any(|(name, _)| *name == "smile"));
+        let smi = emoji_shortcodes_matching("smi");
+        assert_eq!(smi, vec![("smile", "🙂")]);
+        assert!(emoji_shortcodes_matching("zzz").is_empty());
+        assert!(emoji_shortcodes_matching("smi!").is_empty());
+        assert!(emoji_shortcodes_matching("Smile").is_empty());
+    }
+
+    #[test]
+    fn charset_rejects_uppercase_and_punctuation() {
+        assert!(is_valid_shortcode_name("white_check_mark"));
+        assert!(is_valid_shortcode_name("+1"));
+        assert!(is_valid_shortcode_name("-1"));
+        assert!(!is_valid_shortcode_name("White"));
+        assert!(!is_valid_shortcode_name("smile!"));
+        assert!(!is_shortcode_char(':'));
+        assert!(!is_shortcode_char(' '));
+    }
+
+    #[test]
+    fn word_boundary_colon_opens_a_query() {
+        let q = emoji_query_at(":smi", 4, 3).unwrap();
+        assert_eq!(q.source_range, 0..4);
+        assert_eq!(q.query, "smi");
+        assert_eq!(q.document_version, 3);
+
+        let q = emoji_query_at("hello :sm", 9, 1).unwrap();
+        assert_eq!(q.query, "sm");
+        assert_eq!(&"hello :sm"[q.source_range.clone()], ":sm");
+
+        assert!(emoji_query_at(":", 1, 1).is_some());
+        assert!(emoji_query_at("(:", 2, 1).is_some());
+    }
+
+    #[test]
+    fn time_urls_and_alnum_colons_do_not_open() {
+        assert!(emoji_query_at("12:30", 5, 1).is_none());
+        assert!(emoji_query_at("12:30", 3, 1).is_none());
+        assert!(emoji_query_at("https://example.com", 6, 1).is_none());
+        assert!(emoji_query_at("https://example.com", 8, 1).is_none());
+        assert!(emoji_query_at("foo:bar", 4, 1).is_none());
+        assert!(emoji_query_at("a:smi", 5, 1).is_none());
+    }
+
+    #[test]
+    fn confirm_replacement_includes_closing_colon() {
+        assert_eq!(
+            emoji_confirm_replacement("smile").as_deref(),
+            Some(":smile:")
+        );
+        assert_eq!(emoji_confirm_replacement("nope"), None);
+    }
+
+    #[test]
+    fn tokens_in_prose_skip_unknown_names() {
+        let text = "hi :smile: and :nope: :heart:";
+        let tokens = emoji_tokens_in(text);
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(&text[tokens[0].0.clone()], ":smile:");
+        assert_eq!(tokens[0].1, "🙂");
+        assert_eq!(&text[tokens[1].0.clone()], ":heart:");
+    }
+}

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -381,6 +381,10 @@ pub enum Msg {
     StatusOpenInCurrentTabOn,
     /// Status: non-explicit opens now always append a new tab.
     StatusOpenInCurrentTabOff,
+    /// Status: Markdown delimiter auto-pair enabled.
+    StatusMarkdownAutoPairOn,
+    /// Status: Markdown delimiter auto-pair disabled.
+    StatusMarkdownAutoPairOff,
     /// Silent save-to-file enabled.
     StatusSilentSaveOn,
     /// Silent save-to-file disabled (recovery-only).
@@ -841,6 +845,8 @@ pub enum Msg {
     PrefPanelShowHiddenFiles,
     /// "Open documents in current tab" row label.
     PrefPanelOpenInCurrentTab,
+    /// "Markdown auto-pair" row label.
+    PrefPanelMarkdownAutoPair,
     /// "Sidebar" row label.
     PrefPanelSidebar,
     /// "Heading menu" row label.
@@ -1293,9 +1299,11 @@ pub enum P1Msg {
     Close,
     TextAndHeadings,
     Lists,
+    EmojiShortcodes,
+    NoEmojiMatches,
 }
 
-const P1_EN: [&str; 39] = [
+const P1_EN: [&str; 41] = [
     "Recover documents",
     "Choose which recovery snapshots to restore or discard. Unselected snapshots stay safe on disk.",
     "Restore All",
@@ -1335,8 +1343,10 @@ const P1_EN: [&str; 39] = [
     "Close",
     "Text and Headings",
     "Lists",
+    "Emoji",
+    "No matching emoji",
 ];
-const P1_ZH_HANS: [&str; 39] = [
+const P1_ZH_HANS: [&str; 41] = [
     "恢复文档",
     "选择要恢复或放弃的恢复快照。未选择的快照会安全保留在磁盘上。",
     "全部恢复",
@@ -1376,8 +1386,10 @@ const P1_ZH_HANS: [&str; 39] = [
     "关闭",
     "文本与标题",
     "列表",
+    "表情符号",
+    "没有匹配的表情",
 ];
-const P1_ZH_HANT: [&str; 39] = [
+const P1_ZH_HANT: [&str; 41] = [
     "復原文件",
     "選擇要復原或捨棄的復原快照。未選取的快照會安全保留在磁碟上。",
     "全部復原",
@@ -1417,8 +1429,10 @@ const P1_ZH_HANT: [&str; 39] = [
     "關閉",
     "文字與標題",
     "清單",
+    "表情符號",
+    "沒有符合的表情",
 ];
-const P1_JA: [&str; 39] = [
+const P1_JA: [&str; 41] = [
     "文書を復元",
     "復元または破棄するスナップショットを選択します。未選択のものはディスクに保持されます。",
     "すべて復元",
@@ -1458,8 +1472,10 @@ const P1_JA: [&str; 39] = [
     "閉じる",
     "テキストと見出し",
     "リスト",
+    "絵文字",
+    "一致する絵文字はありません",
 ];
-const P1_FR: [&str; 39] = [
+const P1_FR: [&str; 41] = [
     "Récupérer des documents",
     "Choisissez les instantanés à restaurer ou supprimer. Les autres restent sur le disque.",
     "Tout restaurer",
@@ -1499,8 +1515,10 @@ const P1_FR: [&str; 39] = [
     "Fermer",
     "Texte et titres",
     "Listes",
+    "Emoji",
+    "Aucun emoji correspondant",
 ];
-const P1_DE: [&str; 39] = [
+const P1_DE: [&str; 41] = [
     "Dokumente wiederherstellen",
     "Wählen Sie Wiederherstellungen aus. Nicht gewählte bleiben sicher auf dem Datenträger.",
     "Alle wiederherstellen",
@@ -1540,8 +1558,10 @@ const P1_DE: [&str; 39] = [
     "Schließen",
     "Text und Überschriften",
     "Listen",
+    "Emoji",
+    "Keine passenden Emoji",
 ];
-const P1_ES: [&str; 39] = [
+const P1_ES: [&str; 41] = [
     "Recuperar documentos",
     "Elige qué instantáneas restaurar o descartar. Las demás permanecen seguras en el disco.",
     "Restaurar todo",
@@ -1581,6 +1601,8 @@ const P1_ES: [&str; 39] = [
     "Cerrar",
     "Texto y encabezados",
     "Listas",
+    "Emoji",
+    "No hay emojis coincidentes",
 ];
 
 pub fn p1_t(lang: Language, msg: P1Msg) -> &'static str {
@@ -3342,6 +3364,8 @@ fn en(msg: Msg) -> &'static str {
         Msg::StatusShowHiddenFilesOff => "Show hidden files off",
         Msg::StatusOpenInCurrentTabOn => "Open in current tab on",
         Msg::StatusOpenInCurrentTabOff => "Open in current tab off",
+        Msg::StatusMarkdownAutoPairOn => "Markdown auto-pair on",
+        Msg::StatusMarkdownAutoPairOff => "Markdown auto-pair off",
         Msg::StatusSilentSaveOn => "Auto-save to file on",
         Msg::StatusSilentSaveOff => "Auto-save to file off (recovery only)",
         Msg::StatusAutoSaveDelay => "Auto-save delay: {0}s",
@@ -3638,6 +3662,7 @@ fn en(msg: Msg) -> &'static str {
         Msg::PrefPanelSyncScroll => "Sync scroll",
         Msg::PrefPanelShowHiddenFiles => "Show hidden files",
         Msg::PrefPanelOpenInCurrentTab => "Open documents in current tab",
+        Msg::PrefPanelMarkdownAutoPair => "Markdown auto-pair",
         Msg::PrefPanelSidebar => "Sidebar",
         Msg::PrefPanelHeadingMenu => "Heading menu",
         Msg::PrefPanelHeadingMenuThree => "H1–H5",
@@ -3993,6 +4018,8 @@ fn ja(msg: Msg) -> &'static str {
         Msg::StatusShowHiddenFilesOff => "非表示ファイルの表示オフ",
         Msg::StatusOpenInCurrentTabOn => "現在のタブで開くオン",
         Msg::StatusOpenInCurrentTabOff => "現在のタブで開くオフ",
+        Msg::StatusMarkdownAutoPairOn => "Markdown 自動ペアオン",
+        Msg::StatusMarkdownAutoPairOff => "Markdown 自動ペアオフ",
         Msg::StatusSilentSaveOn => "ファイルへの自動保存オン",
         Msg::StatusSilentSaveOff => "ファイルへの自動保存オフ（復旧のみ）",
         Msg::StatusAutoSaveDelay => "自動保存の間隔: {0}秒",
@@ -4294,6 +4321,7 @@ fn ja(msg: Msg) -> &'static str {
         Msg::PrefPanelSyncScroll => "同期スクロール",
         Msg::PrefPanelShowHiddenFiles => "非表示ファイルを表示",
         Msg::PrefPanelOpenInCurrentTab => "現在のタブでドキュメントを開く",
+        Msg::PrefPanelMarkdownAutoPair => "Markdown 自動ペア",
         Msg::PrefPanelHeadingMenu => "見出しメニュー",
         Msg::PrefPanelHeadingMenuThree => "H1–H5",
         Msg::PrefPanelHeadingMenuSix => "H1–H6",
@@ -4637,6 +4665,8 @@ fn fr(msg: Msg) -> &'static str {
         Msg::StatusShowHiddenFilesOff => "Afficher les fichiers cachés désactivé",
         Msg::StatusOpenInCurrentTabOn => "Ouvrir dans l'onglet actif activé",
         Msg::StatusOpenInCurrentTabOff => "Ouvrir dans l'onglet actif désactivé",
+        Msg::StatusMarkdownAutoPairOn => "Appariement Markdown activé",
+        Msg::StatusMarkdownAutoPairOff => "Appariement Markdown désactivé",
         Msg::StatusSilentSaveOn => "Enregistrement auto vers le fichier activé",
         Msg::StatusSilentSaveOff => {
             "Enregistrement auto vers le fichier désactivé (récupération seule)"
@@ -4969,6 +4999,7 @@ fn fr(msg: Msg) -> &'static str {
         Msg::PrefPanelSyncScroll => "Défilement synchronisé",
         Msg::PrefPanelShowHiddenFiles => "Afficher les fichiers cachés",
         Msg::PrefPanelOpenInCurrentTab => "Ouvrir les documents dans l'onglet actif",
+        Msg::PrefPanelMarkdownAutoPair => "Appariement automatique Markdown",
         Msg::PrefPanelHeadingMenu => "Menu des titres",
         Msg::PrefPanelHeadingMenuThree => "H1–H5",
         Msg::PrefPanelHeadingMenuSix => "H1–H6",
@@ -5312,6 +5343,8 @@ fn de(msg: Msg) -> &'static str {
         Msg::StatusShowHiddenFilesOff => "Versteckte Dateien anzeigen aus",
         Msg::StatusOpenInCurrentTabOn => "Im aktuellen Tab öffnen ein",
         Msg::StatusOpenInCurrentTabOff => "Im aktuellen Tab öffnen aus",
+        Msg::StatusMarkdownAutoPairOn => "Markdown-Autopaarung ein",
+        Msg::StatusMarkdownAutoPairOff => "Markdown-Autopaarung aus",
         Msg::StatusSilentSaveOn => "Automatisch in Datei speichern ein",
         Msg::StatusSilentSaveOff => "Automatisch in Datei speichern aus (nur Wiederherstellung)",
         Msg::StatusAutoSaveDelay => "Autospeicher-Intervall: {0}s",
@@ -5630,6 +5663,7 @@ fn de(msg: Msg) -> &'static str {
         Msg::PrefPanelSyncScroll => "Synchrones Scrollen",
         Msg::PrefPanelShowHiddenFiles => "Versteckte Dateien anzeigen",
         Msg::PrefPanelOpenInCurrentTab => "Dokumente im aktuellen Tab öffnen",
+        Msg::PrefPanelMarkdownAutoPair => "Markdown-Autopaarung",
         Msg::PrefPanelHeadingMenu => "Überschriftenmenü",
         Msg::PrefPanelHeadingMenuThree => "H1–H5",
         Msg::PrefPanelHeadingMenuSix => "H1–H6",
@@ -5973,6 +6007,8 @@ fn es(msg: Msg) -> &'static str {
         Msg::StatusShowHiddenFilesOff => "Mostrar archivos ocultos desactivado",
         Msg::StatusOpenInCurrentTabOn => "Abrir en la pestaña actual activado",
         Msg::StatusOpenInCurrentTabOff => "Abrir en la pestaña actual desactivado",
+        Msg::StatusMarkdownAutoPairOn => "Autopareado Markdown activado",
+        Msg::StatusMarkdownAutoPairOff => "Autopareado Markdown desactivado",
         Msg::StatusSilentSaveOn => "Autoguardar en archivo activado",
         Msg::StatusSilentSaveOff => "Autoguardar en archivo desactivado (solo recuperación)",
         Msg::StatusAutoSaveDelay => "Retraso de autoguardado: {0}s",
@@ -6283,6 +6319,7 @@ fn es(msg: Msg) -> &'static str {
         Msg::PrefPanelSyncScroll => "Desplazamiento sincronizado",
         Msg::PrefPanelShowHiddenFiles => "Mostrar archivos ocultos",
         Msg::PrefPanelOpenInCurrentTab => "Abrir documentos en la pestaña actual",
+        Msg::PrefPanelMarkdownAutoPair => "Autopareado Markdown",
         Msg::PrefPanelHeadingMenu => "Menú de encabezados",
         Msg::PrefPanelHeadingMenuThree => "H1–H5",
         Msg::PrefPanelHeadingMenuSix => "H1–H6",
@@ -6628,6 +6665,8 @@ fn zh(msg: Msg) -> &'static str {
         Msg::StatusShowHiddenFilesOff => "显示隐藏文件已关闭",
         Msg::StatusOpenInCurrentTabOn => "在当前标签页打开已开启",
         Msg::StatusOpenInCurrentTabOff => "在当前标签页打开已关闭",
+        Msg::StatusMarkdownAutoPairOn => "Markdown 自动配对已开启",
+        Msg::StatusMarkdownAutoPairOff => "Markdown 自动配对已关闭",
         Msg::StatusSilentSaveOn => "已开启自动保存到原文件",
         Msg::StatusSilentSaveOff => "已关闭自动保存到原文件（仅保留恢复快照）",
         Msg::StatusAutoSaveDelay => "自动保存间隔：{0} 秒",
@@ -6908,6 +6947,7 @@ fn zh(msg: Msg) -> &'static str {
         Msg::PrefPanelSyncScroll => "同步滚动",
         Msg::PrefPanelShowHiddenFiles => "显示隐藏的文件夹/文件",
         Msg::PrefPanelOpenInCurrentTab => "在当前标签页打开文档",
+        Msg::PrefPanelMarkdownAutoPair => "Markdown 自动配对",
         Msg::PrefPanelSidebar => "侧边栏",
         Msg::PrefPanelHeadingMenu => "标题菜单",
         Msg::PrefPanelHeadingMenuThree => "H1–H5",
@@ -7248,6 +7288,8 @@ fn zh_hant(msg: Msg) -> &'static str {
         Msg::StatusShowHiddenFilesOff => "顯示隱藏檔案已關閉",
         Msg::StatusOpenInCurrentTabOn => "在目前分頁開啟已開啟",
         Msg::StatusOpenInCurrentTabOff => "在目前分頁開啟已關閉",
+        Msg::StatusMarkdownAutoPairOn => "Markdown 自動配對已開啟",
+        Msg::StatusMarkdownAutoPairOff => "Markdown 自動配對已關閉",
         Msg::StatusSilentSaveOn => "已開啟自動儲存到原檔案",
         Msg::StatusSilentSaveOff => "已關閉自動儲存到原檔案（僅保留還原快照）",
         Msg::StatusAutoSaveDelay => "自動儲存間隔：{0} 秒",
@@ -7528,6 +7570,7 @@ fn zh_hant(msg: Msg) -> &'static str {
         Msg::PrefPanelSyncScroll => "同步捲動",
         Msg::PrefPanelShowHiddenFiles => "顯示隱藏的資料夾/檔案",
         Msg::PrefPanelOpenInCurrentTab => "在目前分頁開啟文件",
+        Msg::PrefPanelMarkdownAutoPair => "Markdown 自動配對",
         Msg::PrefPanelSidebar => "側邊欄",
         Msg::PrefPanelHeadingMenu => "標題選單",
         Msg::PrefPanelHeadingMenuThree => "H1–H5",
@@ -7740,8 +7783,10 @@ mod tests {
             P1Msg::Close,
             P1Msg::TextAndHeadings,
             P1Msg::Lists,
+            P1Msg::EmojiShortcodes,
+            P1Msg::NoEmojiMatches,
         ];
-        assert_eq!(messages.len(), 39);
+        assert_eq!(messages.len(), 41);
         for language in Language::all() {
             for message in messages {
                 assert!(!p1_t(*language, message).trim().is_empty());
@@ -8247,6 +8292,8 @@ mod tests {
             Msg::StatusShowHiddenFilesOff,
             Msg::StatusOpenInCurrentTabOn,
             Msg::StatusOpenInCurrentTabOff,
+            Msg::StatusMarkdownAutoPairOn,
+            Msg::StatusMarkdownAutoPairOff,
             Msg::StatusSilentSaveOn,
             Msg::StatusSilentSaveOff,
             Msg::StatusAutoSaveDelay,
@@ -8490,6 +8537,7 @@ mod tests {
             Msg::PrefPanelSyncScroll,
             Msg::PrefPanelShowHiddenFiles,
             Msg::PrefPanelOpenInCurrentTab,
+            Msg::PrefPanelMarkdownAutoPair,
             Msg::PrefPanelSidebar,
             Msg::PrefPanelHeadingMenu,
             Msg::PrefPanelTabGeneral,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,12 @@ use std::{
 use pulldown_cmark::{Alignment, CodeBlockKind, CowStr, Event, Parser, Tag, TagEnd, html};
 use regex::RegexBuilder;
 
+mod auto_pair;
 pub mod block_edit;
 mod diagram;
 mod document_memory;
 mod editing;
+mod emoji;
 mod escape;
 mod export;
 mod frontmatter;
@@ -181,7 +183,7 @@ pub use model::{
 };
 pub use visual::{
     build_visual_projection, build_visual_projection_with_marked_range, data_uri_payload_ranges,
-    destination_data_uri_fingerprint, elided_payload_token, format_byte_size,
+    destination_data_uri_fingerprint, elided_payload_token, format_byte_size, task_checkbox_toggle,
 };
 
 /// A compiled find pattern shared by source-document and rendered-preview
@@ -225,6 +227,7 @@ impl SearchPattern {
     }
 }
 
+pub use auto_pair::{AutoPairAction, auto_pair_action, is_auto_pair_restricted_field};
 pub use block_edit::{
     BlockEdit, BlockEditError, BlockPlacement, BlockTarget, BlockTransform, SlashCommand,
     SlashQuery, adjacent_reorder_target, block_can_reorder, block_can_reorder_at,
@@ -233,6 +236,10 @@ pub use block_edit::{
     validate_block_target,
 };
 pub use diagram::{builtin_diagram_registry, diagram_backend_id};
+pub use emoji::{
+    EmojiQuery, emoji_confirm_replacement, emoji_for_shortcode, emoji_query_at,
+    emoji_shortcodes_matching, emoji_tokens_in,
+};
 pub use highlight::{highlight_code, supported_highlight_languages, warm_highlighter};
 pub use i18n::{
     Language, MarkdownReferenceSection, Msg, P0Msg, P1Msg, ShortcutAction, ShortcutCatalog,
@@ -7850,6 +7857,7 @@ Intro.
             sync_scroll: true,
             show_hidden_files: true,
             open_in_current_tab: false,
+            markdown_auto_pair: false,
             sidebar_visible: false,
             sidebar_tab: SidebarTab::Outline,
             language: "zh".to_string(),
@@ -7885,6 +7893,7 @@ Intro.
         assert!(written.contains("background_check = true"));
         assert!(written.contains("heading_menu_max_level = 6"));
         assert!(written.contains("sync_scroll = true"));
+        assert!(written.contains("markdown_auto_pair = false"));
         assert!(written.contains("[auto_save]"));
         assert!(written.contains("silent_save = false"));
         assert!(written.contains("delay_secs = 30"));
@@ -7898,6 +7907,7 @@ Intro.
         assert_eq!(parsed.custom_theme, None);
         assert_eq!(parsed.language, "en");
         assert!(!parsed.preview_adaptive_width);
+        assert!(parsed.markdown_auto_pair);
         assert_eq!(parsed.editor_font_size, DEFAULT_EDITOR_FONT_SIZE);
         assert_eq!(parsed.rendered_font_size, DEFAULT_RENDERED_FONT_SIZE);
         assert_eq!(parsed.paragraph_spacing, DEFAULT_PARAGRAPH_SPACING);

--- a/src/model.rs
+++ b/src/model.rs
@@ -463,6 +463,9 @@ pub struct AppPreferences {
     /// welcome document); a dirty active tab — named or untitled — makes
     /// the open divert to a new tab instead. Enabled by default.
     pub open_in_current_tab: bool,
+    /// When enabled, typing a Markdown opener (`*`, `_`, `` ` ``, `$`, `(`,
+    /// `[`, `{`, `"`, `'`) inserts the matching closer. Enabled by default.
+    pub markdown_auto_pair: bool,
     pub sidebar_visible: bool,
     pub sidebar_tab: SidebarTab,
     /// Interface language preference code (e.g. "en", "zh"). Stored as a
@@ -513,6 +516,7 @@ impl Default for AppPreferences {
             sync_scroll: false,
             show_hidden_files: false,
             open_in_current_tab: true,
+            markdown_auto_pair: true,
             sidebar_visible: true,
             sidebar_tab: SidebarTab::default(),
             language: "en".to_string(),
@@ -1482,6 +1486,9 @@ pub enum VisualRevealKind {
     /// decoded character renders while the complete authored `&…;` token
     /// stays hidden until the caret enters it.
     Entity,
+    /// One `:shortcode:` emoji token: the glyph renders while the complete
+    /// authored `:name:` stays hidden until the caret enters it.
+    Emoji,
     /// One supported inline-HTML element (style pair or `<br>`): the tags stay
     /// hidden markers while the content renders with the mapped style.
     InlineHtml,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2336,7 +2336,7 @@ fn parse_extended_inline_segments(text: &str) -> Vec<ExtendedInlineSegment> {
             && let Some(end) = stripped.find(':')
         {
             let shortcode = &stripped[..end];
-            if let Some(emoji) = emoji_for_shortcode(shortcode) {
+            if let Some(emoji) = crate::emoji::emoji_for_shortcode(shortcode) {
                 segments.push(ExtendedInlineSegment::Emoji(emoji));
                 index += end + 2;
                 continue;
@@ -2455,36 +2455,6 @@ fn is_autolink_boundary(text: &str, start: usize) -> bool {
         .chars()
         .next_back()
         .is_none_or(|ch| ch.is_whitespace() || matches!(ch, '(' | '[' | '{'))
-}
-
-fn emoji_for_shortcode(shortcode: &str) -> Option<&'static str> {
-    if shortcode.is_empty()
-        || shortcode.len() > 32
-        || !shortcode.chars().all(|ch| {
-            ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '_' | '-' | '+')
-        })
-    {
-        return None;
-    }
-
-    match shortcode {
-        "smile" | "slightly_smiling_face" => Some("🙂"),
-        "heart" => Some("❤️"),
-        "+1" | "thumbsup" => Some("👍"),
-        "-1" | "thumbsdown" => Some("👎"),
-        "check" | "white_check_mark" => Some("✅"),
-        "x" => Some("❌"),
-        "warning" => Some("⚠️"),
-        "bulb" | "idea" => Some("💡"),
-        "rocket" => Some("🚀"),
-        "fire" => Some("🔥"),
-        "star" => Some("⭐"),
-        "book" => Some("📘"),
-        "memo" => Some("📝"),
-        "bug" => Some("🐛"),
-        "sparkles" => Some("✨"),
-        _ => None,
-    }
 }
 
 /// pulldown events with adjacent, offset-contiguous `Text` fragments merged.

--- a/src/storage/preferences.rs
+++ b/src/storage/preferences.rs
@@ -84,6 +84,8 @@ struct PreferencesFile {
     show_hidden_files: bool,
     #[serde(deserialize_with = "deserialize_bool_or_true")]
     open_in_current_tab: bool,
+    #[serde(deserialize_with = "deserialize_bool_or_true")]
+    markdown_auto_pair: bool,
     sidebar_visible: bool,
     /// "files" or "outline"; unknown values fall back to Files like the
     /// legacy format did.
@@ -310,6 +312,7 @@ impl From<&AppPreferences> for PreferencesFile {
             sync_scroll: preferences.sync_scroll,
             show_hidden_files: preferences.show_hidden_files,
             open_in_current_tab: preferences.open_in_current_tab,
+            markdown_auto_pair: preferences.markdown_auto_pair,
             sidebar_visible: preferences.sidebar_visible,
             sidebar_tab: match preferences.sidebar_tab {
                 SidebarTab::Files => "files".to_string(),
@@ -372,6 +375,7 @@ impl From<PreferencesFile> for AppPreferences {
             sync_scroll: file.sync_scroll,
             show_hidden_files: file.show_hidden_files,
             open_in_current_tab: file.open_in_current_tab,
+            markdown_auto_pair: file.markdown_auto_pair,
             sidebar_visible: file.sidebar_visible,
             sidebar_tab: match file.sidebar_tab.to_ascii_lowercase().as_str() {
                 "outline" => SidebarTab::Outline,
@@ -996,6 +1000,43 @@ mod tests {
         let text = "theme = \"Paper\"\nopen_in_current_tab = \"yes\"\n";
         let parsed = parse_app_preferences(text).unwrap();
         assert!(parsed.open_in_current_tab);
+    }
+
+    #[test]
+    fn markdown_auto_pair_defaults_to_true() {
+        assert!(AppPreferences::default().markdown_auto_pair);
+    }
+
+    #[test]
+    fn markdown_auto_pair_round_trips_through_toml() {
+        let preferences = AppPreferences {
+            markdown_auto_pair: false,
+            ..AppPreferences::default()
+        };
+        let rendered = render_app_preferences(&preferences);
+        assert!(
+            rendered.contains("markdown_auto_pair = false"),
+            "rendered TOML should set markdown_auto_pair = false: {rendered}"
+        );
+        let parsed = parse_app_preferences(&rendered).unwrap();
+        assert!(
+            !parsed.markdown_auto_pair,
+            "parsed markdown_auto_pair should be false"
+        );
+    }
+
+    #[test]
+    fn missing_markdown_auto_pair_falls_back_to_true() {
+        let text = "theme = \"Paper\"\nlanguage = \"en\"\n";
+        let parsed = parse_app_preferences(text).unwrap();
+        assert!(parsed.markdown_auto_pair);
+    }
+
+    #[test]
+    fn invalid_markdown_auto_pair_value_falls_back_to_true() {
+        let text = "theme = \"Paper\"\nmarkdown_auto_pair = \"yes\"\n";
+        let parsed = parse_app_preferences(text).unwrap();
+        assert!(parsed.markdown_auto_pair);
     }
 
     #[test]

--- a/src/visual.rs
+++ b/src/visual.rs
@@ -530,6 +530,7 @@ pub fn build_visual_projection_with_marked_range(
     }
     projection
 }
+use crate::emoji::{emoji_for_shortcode, emoji_tokens_in};
 use crate::parse::{
     ExtendedInlineKind, InlineHtmlStyleKind, InlineHtmlStyleTag, coalesced_offset_events,
     extended_inline_matches, parse_inline_html_image, parse_inline_html_style_tag,
@@ -2912,7 +2913,8 @@ const NAMED_ENTITY_DECODES: &[(&str, char)] = &[
 const NAMED_ENTITY_DECODES_MULTI: &[(&str, &str)] = &[("NotEqualTilde", "\u{2242}\u{0338}")];
 
 /// Emits an identity-mapped text slice: the slice equals its visible text, so
-/// it is pushed directly or split around extended inline markers.
+/// it is pushed directly or split around extended inline markers and emoji
+/// shortcodes (`:name:` tokens render as glyphs until the caret reveals them).
 fn push_identity_text_runs(
     runs: &mut Vec<VisualInlineRun>,
     candidates: &mut Vec<RevealCandidate>,
@@ -2924,7 +2926,8 @@ fn push_identity_text_runs(
     navigation: Option<VisualNavigationTarget>,
 ) {
     let extended = extended_inline_matches(event_source);
-    if extended.is_empty() {
+    let emojis = emoji_tokens_in(event_source);
+    if extended.is_empty() && emojis.is_empty() {
         push_run(
             runs,
             source,
@@ -2960,6 +2963,16 @@ fn push_identity_text_runs(
             link_target_range: None,
         });
     }
+    for (token_range, glyph) in &emojis {
+        boundaries.extend([token_range.start, token_range.end]);
+        candidates.push(RevealCandidate {
+            kind: VisualRevealKind::Emoji,
+            source_range: event_range.start + token_range.start
+                ..event_range.start + token_range.end,
+            link_target_range: None,
+        });
+        let _ = glyph;
+    }
     boundaries.sort_unstable();
     boundaries.dedup();
 
@@ -2984,6 +2997,20 @@ fn push_identity_text_runs(
                     ExtendedInlineKind::Subscript => style.subscript = true,
                 }
             }
+        }
+        if let Some((_, glyph)) = emojis
+            .iter()
+            .find(|(token, _)| token.start == local_range.start && token.end == local_range.end)
+        {
+            push_decoded_entity_run(
+                runs,
+                glyph,
+                event_range.start + local_range.start..event_range.start + local_range.end,
+                style,
+                link_target_range.clone(),
+                navigation.clone(),
+            );
+            continue;
         }
         let global_range =
             event_range.start + local_range.start..event_range.start + local_range.end;
@@ -3165,6 +3192,12 @@ fn reveal_candidate_is_exact(
                 && source.as_bytes()[1].is_ascii_punctuation()
         }
         VisualRevealKind::Entity => decode_entity_token(source).is_some(),
+        VisualRevealKind::Emoji => {
+            source.starts_with(':')
+                && source.ends_with(':')
+                && source.len() >= 3
+                && emoji_for_shortcode(&source[1..source.len() - 1]).is_some()
+        }
         VisualRevealKind::InlineHtml => {
             matches!(
                 parse_inline_html_style_tag(source),
@@ -3347,6 +3380,36 @@ fn skip_ascii_spacing(text: &str, mut offset: usize) -> usize {
         offset += 1;
     }
     offset
+}
+
+/// Toggle the `[ ]` / `[x]` / `[X]` token inside a task-list prefix.
+/// `[X]` turns off to `[ ]`. Returns the exact marker range and replacement.
+pub fn task_checkbox_toggle(
+    source: &str,
+    prefix: &VisualBlockPrefix,
+) -> Option<(Range<usize>, String)> {
+    if !matches!(prefix.kind, VisualBlockPrefixKind::TaskList { .. }) {
+        return None;
+    }
+    let prefix_text = source.get(prefix.source_range.clone())?;
+    let relative = prefix_text
+        .find("[ ]")
+        .or_else(|| prefix_text.find("[x]").or_else(|| prefix_text.find("[X]")))?;
+    let start = prefix.source_range.start + relative;
+    let end = start + 3;
+    if end > prefix.source_range.end
+        || !source.is_char_boundary(start)
+        || !source.is_char_boundary(end)
+    {
+        return None;
+    }
+    let token = source.get(start..end)?;
+    let replacement = match token {
+        "[ ]" => "[x]",
+        "[x]" | "[X]" => "[ ]",
+        _ => return None,
+    };
+    Some((start..end, replacement.to_string()))
 }
 
 pub(crate) fn structural_prefix_at(text: &str, byte_index: usize) -> Option<VisualBlockPrefix> {
@@ -4243,6 +4306,123 @@ mod tests {
         let hidden = build_visual_projection(titled, block, interior..interior, interior);
         assert_eq!(hidden.text, "Hello");
         assert!(hidden.revealed_source_ranges.is_empty());
+    }
+
+    #[test]
+    fn unfocused_heading_list_and_quote_hide_structural_prefixes() {
+        let source = "## Title\n\n- item\n\n> quoted\n\nnext";
+        let doc = MarkdownDocument::from_text(source);
+        let blocks = doc.visual_blocks();
+        let heading = blocks
+            .iter()
+            .find(|block| matches!(block.kind, VisualBlockKind::Heading { level: 2 }))
+            .unwrap();
+        let list = blocks
+            .iter()
+            .find(|block| matches!(block.kind, VisualBlockKind::ListItem { .. }))
+            .unwrap();
+        let quote = blocks
+            .iter()
+            .find(|block| {
+                block
+                    .quote_context
+                    .as_ref()
+                    .is_some_and(|quote| quote.depth >= 1)
+                    && matches!(block.kind, VisualBlockKind::Paragraph)
+            })
+            .unwrap();
+        let away = source.find("next").unwrap();
+        let heading_proj = build_visual_projection(source, heading, away..away, away);
+        assert!(
+            !heading_proj.text.contains("##"),
+            "unfocused heading should hide hashes, got {:?}",
+            heading_proj.text
+        );
+        assert!(heading_proj.text.contains("Title"));
+        assert_eq!(&source[heading.source_range.clone()].trim_end(), "## Title");
+
+        let list_proj = build_visual_projection(source, list, away..away, away);
+        assert!(
+            !list_proj.text.contains("- "),
+            "unfocused list should hide the marker, got {:?}",
+            list_proj.text
+        );
+        assert!(list_proj.text.contains("item"));
+
+        let quote_proj = build_visual_projection(source, quote, away..away, away);
+        assert!(
+            !quote_proj.text.contains('>'),
+            "unfocused quote should hide the marker, got {:?}",
+            quote_proj.text
+        );
+        assert!(quote_proj.text.contains("quoted"));
+    }
+
+    #[test]
+    fn typed_atx_line_classifies_as_heading_not_prose() {
+        let source = "## Title\n\n";
+        let doc = MarkdownDocument::from_text(source);
+        let heading = doc
+            .visual_blocks()
+            .into_iter()
+            .find(|block| matches!(block.kind, VisualBlockKind::Heading { level: 2 }))
+            .expect("typed ATX line should be a heading");
+        assert_eq!(heading.source_island, None);
+        let away = source.len();
+        let proj = build_visual_projection(source, &heading, away..away, away);
+        assert!(!proj.text.contains("##"));
+        assert!(proj.text.contains("Title"));
+    }
+
+    #[test]
+    fn unfocused_emoji_shortcode_renders_the_glyph() {
+        let source = "hi :smile: there";
+        let doc = MarkdownDocument::from_text(source);
+        let block = &doc.visual_blocks()[0];
+        let away = 0;
+        let hidden = build_visual_projection(source, block, away..away, away);
+        assert!(
+            hidden.text.contains("🙂"),
+            "unfocused Visual Edit should show the emoji glyph, got {:?}",
+            hidden.text
+        );
+        assert!(
+            !hidden.text.contains(":smile:"),
+            "shortcode should stay hidden until revealed, got {:?}",
+            hidden.text
+        );
+        assert!(block.reveal_groups.iter().any(|group| {
+            group.kind == VisualRevealKind::Emoji
+                && &source[group.source_range.clone()] == ":smile:"
+        }));
+        let inside = source.find("smile").unwrap();
+        let revealed = build_visual_projection(source, block, inside..inside, inside);
+        assert!(
+            revealed.text.contains(":smile:"),
+            "caret inside the token should reveal the shortcode, got {:?}",
+            revealed.text
+        );
+    }
+
+    #[test]
+    fn task_checkbox_toggle_flips_markers() {
+        let source = "- [ ] one\n- [x] two\n- [X] three";
+        let doc = MarkdownDocument::from_text(source);
+        let blocks = doc.visual_blocks();
+        let prefixes: Vec<_> = blocks
+            .iter()
+            .filter_map(|block| block.block_prefix.as_ref())
+            .collect();
+        assert_eq!(prefixes.len(), 3);
+        let (range, replacement) = super::task_checkbox_toggle(source, prefixes[0]).unwrap();
+        assert_eq!(&source[range.clone()], "[ ]");
+        assert_eq!(replacement, "[x]");
+        let (range, replacement) = super::task_checkbox_toggle(source, prefixes[1]).unwrap();
+        assert_eq!(&source[range.clone()], "[x]");
+        assert_eq!(replacement, "[ ]");
+        let (range, replacement) = super::task_checkbox_toggle(source, prefixes[2]).unwrap();
+        assert_eq!(&source[range.clone()], "[X]");
+        assert_eq!(replacement, "[ ]");
     }
 
     #[test]

--- a/src/visual.rs
+++ b/src/visual.rs
@@ -4339,7 +4339,7 @@ mod tests {
             heading_proj.text
         );
         assert!(heading_proj.text.contains("Title"));
-        assert_eq!(&source[heading.source_range.clone()].trim_end(), "## Title");
+        assert_eq!(source[heading.source_range.clone()].trim_end(), "## Title");
 
         let list_proj = build_visual_projection(source, list, away..away, away);
         assert!(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
OpenSpec apply：实现 Visual Edit 打字闭环（自动配对、回车后藏块标记、可点击任务复选框、emoji `:` 补全）。`tasks.md` 14/14 已完成。

## 范围

1. **Markdown 自动配对** — `*` `_` `` ` `` `$` `(` `[` `{` `"` `'`；选区包裹、跳过已有闭符、空配对 Backspace 成对删除；代码/公式/图表载荷与 IME 组合期间不配对；Preferences → General 开关（`markdown_auto_pair`，默认开）。不配对 `=`。
2. **回车后藏块标记** — 光标离开标题/列表/任务/引用行后隐藏 `#`、`- `、`>` 等结构前缀；源码不变。
3. **任务列表可点击** — Visual Edit 中点击 ☐/☑ 在 `[ ]` / `[x]` 间切换（一次可撤销的源码变更）；阅读/分栏预览保持只读。关闭 WYSIWYG 路线图缺口 7。
4. **emoji `:` 补全** — 词边界输入 `:` 弹出短码面板，确认写入 `:name:`；不改成 Unicode 字符；时间与 URL 不触发。

## 主要改动

- `src/auto_pair.rs` — 配对决策（Replace / Skip），GPUI 无关
- `src/emoji.rs` — 短码表与查询/确认，`parse.rs` 复用同一表
- `src/app/editor_element.rs` — 在 `replace_text_in_range` 接入自动配对
- `src/app/preview.rs` / `src/app/editing.rs` — Visual Edit 任务复选框命中与切换（点击后不把光标移进前缀，以便连续切换）
- `src/app/root_view.rs` — General 开关 + emoji 面板（复用 slash 面板样式）
- `src/model.rs` / `src/storage/preferences.rs` — `markdown_auto_pair`
- `src/i18n.rs` — 七种语言
- `docs/visual-editing-quality.md` — 关闭缺口 7

## 验证

- `cargo fmt --check` / `cargo fmt --all -- --check` 通过
- `openspec validate add-visual-edit-typing-loop` 通过
- `markion` lib + bin 测试 582 + 582 通过（含新增 GPUI 用例）
- 工作区其余 crate 在隔离全局 git signing 配置后通过；`markion-pdf` 的 `spike_svg_with_text_element` 在本 Linux 镜像上因 `usvg` fontdb `load_system_fonts()` 得到 0 个字体而失败，与本次改动无关

下一步：`/openspec:archive`（或 `/opsx:archive`）把 delta spec 同步进 `openspec/specs/`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ea51bb9-1250-459a-9ab4-9dd7f757b3f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ea51bb9-1250-459a-9ab4-9dd7f757b3f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

